### PR TITLE
Remove database schema section from PR template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -25,9 +25,6 @@ Delete this section if it isn't applicable to the PR.
 
 Delete this section if it isn't applicable to the PR.
 
-#### Requires Database Schema Changes?
-YES | NO
-
 #### Requires Full Reindexing of all Sources?
 YES | NO
 


### PR DESCRIPTION
There won't be a database for this app, so this section isn't needed.

#### What does this PR do?

Removes the database schema changes section of the PR template. There won't be a database so it's not necessary. Closes #11.

#### What are the relevant tickets?

None

#### Requires Database Schema Changes?
For the last time, NO

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO
