### PR TITLE
Add CLI package

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,12 +17,21 @@
   pruneopts = "UT"
   revision = "03a360545cd2fdc1b872fc3f929186df81b3a4a5"
 
+[[projects]]
+  digest = "1:b24d38b282bacf9791408a080f606370efa3d364e4b5fd9ba0f7b87786d3b679"
+  name = "github.com/urfave/cli"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
+  version = "v1.20.0"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
     "github.com/davecgh/go-spew/spew",
     "github.com/miku/marc21",
+    "github.com/urfave/cli",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/main.go
+++ b/main.go
@@ -1,8 +1,39 @@
 package main
 
-import "github.com/MITLibraries/mario/parsers"
+import (
+	"fmt"
+	"log"
+	"os"
 
-// go run . < fixtures/test.mrc
+	"github.com/mitlibraries/mario/parsers"
+	"github.com/urfave/cli"
+)
+
 func main() {
-	marc.Process("fixtures/marc_rules.json")
+	app := cli.NewApp()
+	app.Commands = []cli.Command{
+		{
+			Name: "parse",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "rules",
+					Value: "fixtures/marc_rules.json",
+					Usage: "Path to marc rules file",
+				},
+			},
+			Action: func(c *cli.Context) error {
+				marc.Process(os.Stdin, c.String("rules"))
+				return nil
+			},
+		},
+	}
+	app.Action = func(c *cli.Context) error {
+		fmt.Println("Reserved for λ")
+		return nil
+	}
+
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/parsers/marc.go
+++ b/parsers/marc.go
@@ -52,7 +52,7 @@ func RetrieveRules(rulefile string) ([]*Rules, error) {
 }
 
 // Process kicks off the MARC processing
-func Process(rulesfile string) {
+func Process(marcfile io.Reader, rulesfile string) {
 
 	var records []record
 
@@ -65,7 +65,7 @@ func Process(rulesfile string) {
 	// loop over all records
 	count := 0
 	for {
-		record, err := marc21.ReadRecord(os.Stdin)
+		record, err := marc21.ReadRecord(marcfile)
 
 		// if we get an error, log it
 		if err != nil {


### PR DESCRIPTION
This adds one of the more widely used, lightweight cli packages. Nothing
has changed in the way it works except that a rules file can now be
passed as an option rather than being hardcoded.

#### How can a reviewer manually see the effects of these changes?

The new CLI can be interacted with as follows:
```
$ go run main.go --help
$ go run main.go parse --rules fixtures/marc_rules.json < fixtures/test.mrc
```

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-124

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
YES

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
