### PR TITLE
Use flag instead of stdin to supply file to process

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,8 @@ func main() {
 	app := cli.NewApp()
 	app.Commands = []cli.Command{
 		{
-			Name: "parse",
+			Name:      "parse",
+			ArgsUsage: "[filepath or - to use stdin]",
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "rules",
@@ -22,7 +23,25 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				marc.Process(os.Stdin, c.String("rules"))
+				var file *os.File
+				var err error
+
+				// if a file path is passed as a flag
+				if c.Args().Get(0) != "-" {
+					// Open the file.
+					file, err = os.Open(c.Args().Get(0))
+				} else {
+					// otherwise try to use stdin
+					file = os.Stdin
+				}
+
+				if err != nil {
+					return err
+				}
+
+				defer file.Close()
+
+				marc.Process(file, c.String("rules"))
 				return nil
 			},
 		},


### PR DESCRIPTION
#### What does this PR do?

Changes from stdin to a supplied file path for signifying the MARC file to process.

#### Helpful background context

Debugging with stdin was proving difficult at best so switching this this now rather than later will make my life somewhat easier.

#### How can a reviewer manually see the effects of these changes?

- go run main.go parse -h
- go run main.go parse --rules fixtures/marc_rules.json fixtures/test.mrc
- go run main.go parse fixtures/test.mrc
- go run main.go parse - < fixtures/record1.mrc

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO
