### PR TITLE
Improve marc rules retrieval and add more rules

### DIFF
--- a/fixtures/marc_rules.json
+++ b/fixtures/marc_rules.json
@@ -43,5 +43,10 @@
     "field":"isbn",
     "tag":"020",
     "subfields":"aq"
+  },
+  {
+    "field":"year",
+    "tag":"008",
+    "subfields":"a"
   }
 ]

--- a/parsers/marc_test.go
+++ b/parsers/marc_test.go
@@ -131,4 +131,51 @@ func TestMarcToRecord(t *testing.T) {
 	if item.url != nil {
 		t.Error("Expected no matches, got", item.url)
 	}
+
+	if item.year != "1993" {
+		t.Error("Expected match, got", item.year)
+	}
+}
+
+var contenttypetests = []struct {
+	in  byte
+	out string
+}{
+	{'a', "Text"},
+	{'b', "Text"},
+	{'c', "Musical score"},
+	{'d', "Musical score"},
+	{'e', "Cartographic material"},
+	{'f', "Cartographic material"},
+	{'g', "Moving image"},
+	{'h', "Text"},
+	{'i', "Sound recording"},
+	{'j', "Sound recording"},
+	{'k', "Still image"},
+	{'l', "Text"},
+	{'m', "Computer file"},
+	{'n', "Text"},
+	{'o', "Kit"},
+	{'p', "Mixed materials"},
+	{'q', "Text"},
+	{'r', "Object"},
+	{'s', "Text"},
+	{'t', "Text"},
+	{'u', "Text"},
+	{'v', "Text"},
+	{'w', "Text"},
+	{'x', "Text"},
+	{'y', "Text"},
+	{'z', "Text"},
+}
+
+func TestContentType(t *testing.T) {
+	for _, ct := range contenttypetests {
+		t.Run(string(ct.in), func(t *testing.T) {
+			ctCase := contentType(ct.in)
+			if ctCase != ct.out {
+				t.Errorf("got %q, want %q", ctCase, ct.out)
+			}
+		})
+	}
 }


### PR DESCRIPTION
#### What does this PR do?

Initial marc rules retrieval was done based on the order of the rules in the file which was not going to be sustainavble longerm. This provides a `getRule` method that allows retrieving by MARC tag string which is at least an improvement even if does not end up as our final form.

Adds handling for content_type which demonstrates our ability to pull from the leader (and then uses a lookup table to translate the byte to a text representaton.

Adds handling for the year of publication which demonstrates our ability to take a portion of a returned subfield. :see_no_evil:

Documents that our implementation of 856 is naive and not what we need to do longterm.

#### How can a reviewer manually see the effects of these changes?

`go run main.go parse fixtures/record1.mrc` and see the additional data fields are now populated.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-134

#### Requires Full Reindexing of all Sources?
YES (if we had any)

#### Includes new or updated dependencies?
NO
