### PR TITLE
Send records to channel for later consumption by es and JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Don't include vendored libraries
 vendor/
+debug
+.debug_config

--- a/parsers/marc.go
+++ b/parsers/marc.go
@@ -157,7 +157,7 @@ func ConsumeRecords(rec <-chan record, done chan<- bool) {
 
 // trasforms a single marc21 record into our internal record struct
 func marcToRecord(marcRecord *marc21.Record, rules []*Rule) record {
-	r := new(record)
+	r := record{}
 
 	r.identifier = marcRecord.Identifier()
 
@@ -199,7 +199,7 @@ func marcToRecord(marcRecord *marc21.Record, rules []*Rule) record {
 
 	// content type LDR/06:1
 	r.contentType = contentType(marcRecord.Leader.Type)
-	return *r
+	return r
 }
 
 // returns slice of string representations of marc fields taking into account the rules for which fields and subfields we care about as defined in marc_rules.json


### PR DESCRIPTION
#### What does this PR do?

Creates channels and sends Records over the channel.

This allows for processing as the records are entering the system
rather than storing them all in memory before processing.

#### How can a reviewer manually see the effects of these changes?

Running the 50,000 record dump we have from Aleph will now take 6MB of RAM instead of 8GB.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-140

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO
