### PR TITLE
Refactor project layout

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 
-	"github.com/mitlibraries/mario/parsers"
 	"github.com/urfave/cli"
 )
 
@@ -41,7 +40,7 @@ func main() {
 
 				defer file.Close()
 
-				marc.Process(file, c.String("rules"))
+				Process(file, c.String("rules"))
 				return nil
 			},
 		},

--- a/marc.go
+++ b/marc.go
@@ -1,4 +1,4 @@
-package marc
+package main
 
 import (
 	"encoding/json"

--- a/marc_test.go
+++ b/marc_test.go
@@ -1,4 +1,4 @@
-package marc
+package main
 
 import (
 	"os"
@@ -23,7 +23,7 @@ func TestContains(t *testing.T) {
 }
 
 func TestCollectSubfields(t *testing.T) {
-	file, err := os.Open("../fixtures/record1.mrc")
+	file, err := os.Open("fixtures/record1.mrc")
 	if err != nil {
 		t.Error(err)
 	}
@@ -66,7 +66,7 @@ func TestCollectSubfields(t *testing.T) {
 }
 
 func TestStringifySelectSubfields(t *testing.T) {
-	file, err := os.Open("../fixtures/record1.mrc")
+	file, err := os.Open("fixtures/record1.mrc")
 	if err != nil {
 		t.Error(err)
 	}
@@ -97,7 +97,7 @@ func TestStringifySelectSubfields(t *testing.T) {
 }
 
 func TestMarcToRecord(t *testing.T) {
-	file, err := os.Open("../fixtures/record1.mrc")
+	file, err := os.Open("fixtures/record1.mrc")
 	if err != nil {
 		t.Error(err)
 	}
@@ -106,7 +106,7 @@ func TestMarcToRecord(t *testing.T) {
 		t.Error(err)
 	}
 
-	rules, err := RetrieveRules("../fixtures/marc_rules.json")
+	rules, err := RetrieveRules("fixtures/marc_rules.json")
 	if err != nil {
 		spew.Dump(err)
 		return


### PR DESCRIPTION
I started running into circular imports with the old project layout. One
solution is to pull marc.Process out into a new package. This should be
pulled out of marc.go eventually anyways. The other solution, which I've
done here, is to just flatten the project into a single package. This is
the easiest, most straightforward solution, and a layout many go
projects adopt.

#### What does this PR do?

The moves the parser package up one level into main. 

#### How can a reviewer manually see the effects of these changes?

The project layout is flatter. `go build`, `go test` and `go install` can all be run from the project root now.

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
