### PR TITLE
Add Elasticsearch bulk loader

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,11 +11,44 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:aa3d8d42865c42626b5c1add193692d045b3188b1479f0a0a88690d21fe20083"
+  name = "github.com/mailru/easyjson"
+  packages = [
+    ".",
+    "buffer",
+    "jlexer",
+    "jwriter",
+  ]
+  pruneopts = "UT"
+  revision = "60711f1a8329503b04e1c88535f419d0bb440bff"
+
+[[projects]]
+  branch = "master"
   digest = "1:a21b0341d1c8cd522235e6b39e4bec263572d9cf1825a3bc548f6618d48a0a27"
   name = "github.com/miku/marc21"
   packages = ["."]
   pruneopts = "UT"
   revision = "03a360545cd2fdc1b872fc3f929186df81b3a4a5"
+
+[[projects]]
+  digest = "1:e01edb58fc507572461d56a8d24632c99af04686005dd5b411ec4b0029a24151"
+  name = "github.com/olivere/elastic"
+  packages = [
+    ".",
+    "config",
+    "uritemplates",
+  ]
+  pruneopts = "UT"
+  revision = "bd115a1132ece51519151c33b5d74e1387d3265a"
+  version = "v6.2.8"
+
+[[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
 
 [[projects]]
   digest = "1:b24d38b282bacf9791408a080f606370efa3d364e4b5fd9ba0f7b87786d3b679"
@@ -31,6 +64,7 @@
   input-imports = [
     "github.com/davecgh/go-spew/spew",
     "github.com/miku/marc21",
+    "github.com/olivere/elastic",
     "github.com/urfave/cli",
   ]
   solver-name = "gps-cdcl"

--- a/consumers.go
+++ b/consumers.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/olivere/elastic"
+)
+
+type Consumer interface {
+	Consume(<-chan Record, chan<- bool)
+}
+
+type ESConsumer struct {
+	Index string
+	RType string
+	p     *elastic.BulkProcessor
+}
+
+func (es *ESConsumer) Consume(recs <-chan Record, done chan<- bool) {
+	for r := range recs {
+		d := elastic.NewBulkIndexRequest().Index(es.Index).Type(es.RType).Doc(r)
+		es.p.Add(d)
+	}
+	done <- true
+}

--- a/main.go
+++ b/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
 
+	"github.com/olivere/elastic"
 	"github.com/urfave/cli"
 )
 
@@ -41,6 +43,24 @@ func main() {
 				defer file.Close()
 
 				Process(file, c.String("rules"))
+				return nil
+			},
+		},
+		{
+			Name: "create",
+			Action: func(c *cli.Context) error {
+				client, err := elastic.NewSimpleClient()
+				if err != nil {
+					return err
+				}
+				ctx := context.Background()
+				created, err := client.CreateIndex("timdex").Do(ctx)
+				if err != nil {
+					return err
+				}
+				if !created.Acknowledged {
+					fmt.Println("Elasticsearch couldn't create the index")
+				}
 				return nil
 			},
 		},


### PR DESCRIPTION
#### What does this PR do?

This adds Elasticsearch bulk indexing capabilities. Things are pretty hard coded at the moment until we can refactor the pipeline. I've also stubbed out a create subcommand that will create a (hardcoded) index. We will likely want to add more functionality here in the future.

#### How can a reviewer manually see the effects of these changes?

1. ```$ go build && go install```
2. Start up an Elasticsearch instance on port 9200:
 ```
$ docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:6.4.2
```

3. Create an index: `$ mario create`

4. Index things: `$ mario parse fixtures/mit_test_records.mrc`

5. Go to `http://localhost:9200/timdex/_search?q=*` in your browser.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-138

#### Requires Full Reindexing of all Sources?
YES

#### Includes new or updated dependencies?
YES

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
