### PR TITLE
Add JSON consumer and CLI flag for JSON output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 vendor/
 debug
 .debug_config
+
+# System files
+.DS_Store

--- a/consumers.go
+++ b/consumers.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"encoding/json"
+	"log"
+
 	"github.com/olivere/elastic"
 )
 
@@ -18,6 +21,21 @@ func (es *ESConsumer) Consume(recs <-chan Record, done chan<- bool) {
 	for r := range recs {
 		d := elastic.NewBulkIndexRequest().Index(es.Index).Type(es.RType).Doc(r)
 		es.p.Add(d)
+	}
+	done <- true
+}
+
+type JSONConsumer struct {
+	Output string
+}
+
+func (js *JSONConsumer) Consume(recs <-chan Record, done chan<- bool) {
+	for r := range recs {
+		b, err := json.MarshalIndent(r, "", "    ")
+		if err != nil {
+			log.Println(err)
+		}
+		log.Println(string(b))
 	}
 	done <- true
 }

--- a/main.go
+++ b/main.go
@@ -22,6 +22,11 @@ func main() {
 					Value: "fixtures/marc_rules.json",
 					Usage: "Path to marc rules file",
 				},
+				cli.StringFlag{
+					Name:  "consumer, c",
+					Value: "es",
+					Usage: "Consumer to use (es or json, default is es)",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				var file *os.File
@@ -42,7 +47,7 @@ func main() {
 
 				defer file.Close()
 
-				Process(file, c.String("rules"))
+				Process(file, c.String("rules"), c.String("consumer"))
 				return nil
 			},
 		},

--- a/marc.go
+++ b/marc.go
@@ -123,7 +123,7 @@ func (m *MarcParser) Parse() {
 }
 
 // Process kicks off the MARC processing
-func Process(marcfile io.Reader, rulesfile string) {
+func Process(marcfile io.Reader, rulesfile string, consumer_type string) {
 	rules, err := RetrieveRules(rulesfile)
 
 	if err != nil {
@@ -143,7 +143,12 @@ func Process(marcfile io.Reader, rulesfile string) {
 	}
 	defer es.Close()
 
-	consumer := ESConsumer{Index: "timdex", RType: "marc", p: es}
+	var consumer Consumer
+	if consumer_type == "json" {
+		consumer = &JSONConsumer{Output: "log"}
+	} else {
+		consumer = &ESConsumer{Index: "timdex", RType: "marc", p: es}
+	}
 
 	out := make(chan Record)
 	done := make(chan bool, 1)


### PR DESCRIPTION
#### What does this PR do?

Adds a JSON consumer so that records can be consumed and exported as JSON instead of to Elasticsearch. Also adds a CLI flag to specify JSON output. Default is Elasticsearch consumer.

JSON output currently prints to log, but we can add additional output streams (file, etc.) as needed.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-126

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
