### PR TITLE
export valid json to stdout

### DIFF
--- a/consumers.go
+++ b/consumers.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 
 	"github.com/olivere/elastic"
 )
 
+// Consumer defines an interface to be implemented by various consumers
 type Consumer interface {
 	Consume(<-chan Record, chan<- bool)
 }
@@ -30,12 +32,30 @@ type JSONConsumer struct {
 }
 
 func (js *JSONConsumer) Consume(recs <-chan Record, done chan<- bool) {
+	fmt.Println("[")
+	var i int
 	for r := range recs {
 		b, err := json.MarshalIndent(r, "", "    ")
 		if err != nil {
 			log.Println(err)
 		}
-		log.Println(string(b))
+		if i != 0 {
+			fmt.Println(",")
+		}
+		fmt.Println(string(b))
+		i++
 	}
+	fmt.Println("]")
+	done <- true
+}
+
+type TitleConsumer struct {
+}
+
+func (ti *TitleConsumer) Consume(recs <-chan Record, done chan<- bool) {
+	for r := range recs {
+		fmt.Println(r.Title)
+	}
+
 	done <- true
 }

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func main() {
 				cli.StringFlag{
 					Name:  "consumer, c",
 					Value: "es",
-					Usage: "Consumer to use (es or json, default is es)",
+					Usage: "Consumer to use (es, json or title; default is es)",
 				},
 			},
 			Action: func(c *cli.Context) error {

--- a/marc.go
+++ b/marc.go
@@ -146,6 +146,8 @@ func Process(marcfile io.Reader, rulesfile string, consumer_type string) {
 	var consumer Consumer
 	if consumer_type == "json" {
 		consumer = &JSONConsumer{Output: "log"}
+	} else if consumer_type == "title" {
+		consumer = &TitleConsumer{}
 	} else {
 		consumer = &ESConsumer{Index: "timdex", RType: "marc", p: es}
 	}


### PR DESCRIPTION
#### What does this PR do?

Log writes to stderr, print logs to stdout.

I wanted to be able to export our json to a file and this allows that. It also tweaks the json creation slightly to create valid json by creating the array syntax and adding comma separators.

I also slipped the original consumer back in because I felt for the stage I am at in development I really just want a quick dump of information and not full data structures or es writes. I can be swayed this is not useful later... but I kinda do want this in for now if it doesn't make anyone super angry.

#### How can a reviewer manually see the effects of these changes?

`go install; mario parse fixtures/mit_test_records.mrc --consumer json > yo.json`

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO
