### PR TITLE
Additional MARC mappings

### DIFF
--- a/consumers.go
+++ b/consumers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 
 	"github.com/olivere/elastic"
@@ -28,11 +29,11 @@ func (es *ESConsumer) Consume(recs <-chan Record, done chan<- bool) {
 }
 
 type JSONConsumer struct {
-	Output string
+	out io.Writer
 }
 
 func (js *JSONConsumer) Consume(recs <-chan Record, done chan<- bool) {
-	fmt.Println("[")
+	fmt.Fprintln(js.out, "[")
 	var i int
 	for r := range recs {
 		b, err := json.MarshalIndent(r, "", "    ")
@@ -40,21 +41,22 @@ func (js *JSONConsumer) Consume(recs <-chan Record, done chan<- bool) {
 			log.Println(err)
 		}
 		if i != 0 {
-			fmt.Println(",")
+			fmt.Fprintln(js.out, ",")
 		}
-		fmt.Println(string(b))
+		fmt.Fprintln(js.out, string(b))
 		i++
 	}
-	fmt.Println("]")
+	fmt.Fprintln(js.out, "]")
 	done <- true
 }
 
 type TitleConsumer struct {
+	out io.Writer
 }
 
 func (ti *TitleConsumer) Consume(recs <-chan Record, done chan<- bool) {
 	for r := range recs {
-		fmt.Println(r.Title)
+		fmt.Fprintln(ti.out, r.Title)
 	}
 
 	done <- true

--- a/consumers_test.go
+++ b/consumers_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestTitleConsumerConsume(t *testing.T) {
+	rules, err := RetrieveRules("fixtures/marc_rules.json")
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	marcfile, err := os.Open("fixtures/record1.mrc")
+	if err != nil {
+		t.Error(err)
+	}
+	done := make(chan bool, 1)
+	out := make(chan Record)
+
+	p := MarcParser{file: marcfile, rules: rules, out: out}
+	go p.Parse()
+
+	var b bytes.Buffer
+	consumer := &TitleConsumer{out: &b}
+	go consumer.Consume(out, done)
+
+	// wait until the ConsumeRecords routine reports it is done via `done` channel
+	<-done
+
+	if strings.TrimSpace(b.String()) != "Arithmetic /" {
+		t.Error("Expected match, got", b.String())
+	}
+}
+
+func TestTitleJsonConsume(t *testing.T) {
+	rules, err := RetrieveRules("fixtures/marc_rules.json")
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	marcfile, err := os.Open("fixtures/mit_test_records.mrc")
+	if err != nil {
+		t.Error(err)
+	}
+	done := make(chan bool, 1)
+	out := make(chan Record)
+
+	p := MarcParser{file: marcfile, rules: rules, out: out}
+	go p.Parse()
+
+	var b bytes.Buffer
+	consumer := &JSONConsumer{out: &b}
+	go consumer.Consume(out, done)
+
+	// wait until the ConsumeRecords routine reports it is done via `done` channel
+	<-done
+
+	var records []*Record
+	json.NewDecoder(&b).Decode(&records)
+
+	if records[0].Title != "Black Panther adventures." {
+		t.Error("Expected match, got", records[0].Title)
+	}
+	if records[0].Identifier != "002621216" {
+		t.Error("Expected match, got", records[0].Identifier)
+	}
+}

--- a/fixtures/marc_rules.json
+++ b/fixtures/marc_rules.json
@@ -66,7 +66,7 @@
     ]
   },
   {
-    "label": "year",
+    "label": "publication_date",
     "array": false,
     "fields": [
       {
@@ -208,6 +208,16 @@
     ]
   },
   {
+    "label": "numbering",
+    "array": false,
+    "fields": [
+      {
+        "tag": "362",
+        "subfields": "a"
+      }
+    ]
+  },
+  {
     "label": "notes",
     "array": true,
     "fields": [
@@ -250,6 +260,14 @@
       {
         "tag": "534",
         "subfields": "abcefklmnoptxz"
+      },
+      {
+        "tag": "588",
+        "subfields": "a"
+      },
+      {
+        "tag": "590",
+        "subfields": "a"
       }
     ]
   },
@@ -301,7 +319,18 @@
     "fields": [
       {
         "tag": "852",
-        "subfields": "bk",
+        "subfields": "b",
+        "notes": "Lookup table required to translate values from those fields"
+      }
+    ]
+  },
+  {
+    "label": "format",
+    "array": true,
+    "fields": [
+      {
+        "tag": "852",
+        "subfields": "k",
         "notes": "Lookup table required to translate values from those fields"
       }
     ]
@@ -313,7 +342,18 @@
       {
         "tag": "LDR",
         "bytes": "06:1",
-        "notes": "get this from the marc21 library directly"
+        "notes": "get this from the marc21 library directly; lookup table required."
+      }
+    ]
+  },
+  {
+    "label": "literary_form",
+    "array": true,
+    "fields": [
+      {
+        "tag": "008",
+        "bytes": "33:1",
+        "notes": "0, s, e = nonfiction ; all other (except empty) = fiction; empty = don't include this field"
       }
     ]
   },


### PR DESCRIPTION
#### What does this PR do?

- Completes https://mitlibraries.atlassian.net/browse/DIP-139 with some
exceptions that will be opened on individual tickets for resolving in
a future sprint.

- Adds initial Consumer testing by providing an io.Writer to the Consumer functions that we default to stdout in normal use but can override to a buffer in testing. ES consumer will require a different approach.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-139

#### Requires Full Reindexing of all Sources?
YES

#### Includes new or updated dependencies?
NO
