### PR TITLE
Support for multiple data sources

### DIFF
--- a/consumers_test.go
+++ b/consumers_test.go
@@ -23,8 +23,8 @@ func TestTitleConsumerConsume(t *testing.T) {
 	done := make(chan bool, 1)
 	out := make(chan Record)
 
-	p := MarcParser{file: marcfile, rules: rules, out: out}
-	go p.Parse()
+	p := MarcParser{file: marcfile, rules: rules}
+	go p.Parse(out)
 
 	var b bytes.Buffer
 	consumer := &TitleConsumer{out: &b}
@@ -46,15 +46,15 @@ func TestTitleJsonConsume(t *testing.T) {
 		return
 	}
 
-	marcfile, err := os.Open("fixtures/mit_test_records.mrc")
+	marcfile, err := os.Open("fixtures/test.mrc")
 	if err != nil {
 		t.Error(err)
 	}
 	done := make(chan bool, 1)
 	out := make(chan Record)
 
-	p := MarcParser{file: marcfile, rules: rules, out: out}
-	go p.Parse()
+	p := MarcParser{file: marcfile, rules: rules}
+	go p.Parse(out)
 
 	var b bytes.Buffer
 	consumer := &JSONConsumer{out: &b}
@@ -66,10 +66,10 @@ func TestTitleJsonConsume(t *testing.T) {
 	var records []*Record
 	json.NewDecoder(&b).Decode(&records)
 
-	if records[0].Title != "Black Panther adventures." {
+	if records[0].Title != "Diagnostic histochemistry" {
 		t.Error("Expected match, got", records[0].Title)
 	}
-	if records[0].Identifier != "002621216" {
+	if records[0].Identifier != "50001" {
 		t.Error("Expected match, got", records[0].Identifier)
 	}
 }

--- a/jsonrecord.go
+++ b/jsonrecord.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+)
+
+type JSONParser struct {
+	file io.Reader
+}
+
+type JSONProcessor struct {
+	file     io.Reader
+	consumer Consumer
+	out      chan Record
+	done     chan bool
+}
+
+func (j *JSONParser) Parse(out chan Record) {
+	ingested = 0
+	decoder := json.NewDecoder(j.file)
+
+	// read open bracket
+	_, err := decoder.Token()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for decoder.More() {
+		var r Record
+		err = decoder.Decode(&r)
+		if err != nil {
+			log.Fatal(err)
+		}
+		ingested++
+		out <- r
+	}
+
+	// read closing bracket
+	_, err = decoder.Token()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	close(out)
+}
+
+func (j *JSONProcessor) Process() {
+	p := JSONParser{file: j.file}
+	go p.Parse(j.out)
+	go j.consumer.Consume(j.out, j.done)
+
+	// wait until the Consume routine reports `done` channel
+	<-j.done
+
+	log.Println("Ingested ", ingested, "records")
+}

--- a/jsonrecord_test.go
+++ b/jsonrecord_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestJsonParser(t *testing.T) {
+	jsonfile, err := os.Open("fixtures/mit_test_records.json")
+	if err != nil {
+		t.Error(err)
+	}
+
+	out := make(chan Record)
+
+	p := JSONParser{file: jsonfile}
+	go p.Parse(out)
+
+	var chanLength int
+	for _ = range out {
+		chanLength++
+	}
+
+	if chanLength != 1962 {
+		t.Error("Expected match, got", chanLength)
+	}
+}
+
+func TestJsonProcess(t *testing.T) {
+	jsonfile, err := os.Open("fixtures/mit_test_records.json")
+	if err != nil {
+		t.Error(err)
+	}
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	tmp := os.Stdout
+	os.Stdout, _ = os.Open(os.DevNull)
+	out := make(chan Record)
+	done := make(chan bool, 1)
+
+	consumer := &TitleConsumer{out: os.Stdout}
+	p := JSONProcessor{file: jsonfile, consumer: consumer, out: out, done: done}
+	p.Process()
+
+	log.SetOutput(os.Stderr)
+	os.Stdout = tmp
+	if !strings.Contains(buf.String(), "Ingested  1962 records") {
+		t.Error("Expected match, got", buf.String())
+	}
+}

--- a/record.go
+++ b/record.go
@@ -1,0 +1,93 @@
+package main
+
+// Record struct stores our internal mappings of data and is used to when
+// mapping various external data sources before sending to elasticsearch
+type Record struct {
+	Identifier           string
+	Title                string
+	AlternateTitles      []string
+	Creator              []string
+	Contributor          []*Contributor
+	URL                  []string
+	Subject              []string
+	Isbn                 []string
+	Issn                 []string
+	Doi                  []string
+	OclcNumber           []string
+	Lccn                 string
+	Country              string
+	Language             []string
+	PublicationDate      string
+	ContentType          string
+	CallNumber           []string
+	Edition              string
+	Imprint              []string
+	PhysicalDescription  string
+	PublicationFrequency []string
+	Numbering            string
+	Notes                []string
+	Contents             []string
+	Summary              []string
+	Format               []string
+	LiteraryForm         string
+	RelatedPlace         []string
+	InBibliography       []string
+	RelatedItems         []*RelatedItem
+	Links                []Link
+	Holdings             []Holdings
+}
+
+// Contributor is a port of a Record
+type Contributor struct {
+	Kind  string
+	Value []string
+}
+
+// RelatedItem is a port of a Record
+type RelatedItem struct {
+	Kind  string
+	Value []string
+}
+
+// Link is a port of a Record
+type Link struct {
+	Kind         string
+	Text         string
+	URL          string
+	Restrictions string
+}
+
+// Holdings is a port of a Record
+type Holdings struct {
+	Location   string
+	CallNumber string
+	Status     string
+}
+
+// Rule defines where the rules are in JSON
+type Rule struct {
+	Label  string   `json:"label"`
+	Array  bool     `json:"array"`
+	Fields []*Field `json:"fields"`
+}
+
+// Field defines where the Fields within a Rule are in JSON
+type Field struct {
+	Tag       string `json:"tag"`
+	Subfields string `json:"subfields"`
+	Bytes     string `json:"bytes"`
+	Kind      string `json:"kind"`
+}
+
+// Parser defines an interface common to parsers
+type Parser interface {
+	Parse(chan Record)
+}
+
+// Processor is an interface that allows converting from custom data into
+// our Record structure
+type Processor interface {
+	Process()
+}
+
+var ingested int


### PR DESCRIPTION
#### What does this PR do?

- adds support for ingesting json files created using the JSONConsumer
- moves some shared Record logic to a generic file
- creates Process interface
- adds `type` flag to cli. This defaults to marc for now as that will be our primary use case for a while still
- a couple tests use smaller data set to speed up test runs

#### Helpful background context

The main.main() logic is getting really convoluted and should be addressed. I think this works adds enough general information about how we'll handle multiple data sources in the future to let us think about how we might address this. It is my opinion that should be handled in a separate PR.

#### How can a reviewer manually see the effects of these changes?

```
go install; mario parse fixtures/mit_test_records.json  --consumer json --type json
```

#### What are the relevant tickets?

- none; oops.

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO

