### PR TITLE
Update in_bibliography rule

### DIFF
--- a/fixtures/marc_rules.json
+++ b/fixtures/marc_rules.json
@@ -476,8 +476,8 @@
     "array": true,
     "fields": [
       {
-        "tag": "581",
-        "subfields": "az"
+        "tag": "510",
+        "subfields": "abcx"
       }
     ]
   },


### PR DESCRIPTION
#### What does this PR do?

This updates the `in_bibliography` rule after discussion with the metadata team. We now get matches in the test record set.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-157

#### Requires Full Reindexing of all Sources?
YES

#### Includes new or updated dependencies?
NO
