### PR TITLE
Separate out pipeline functionality.

### DIFF
--- a/consumers_test.go
+++ b/consumers_test.go
@@ -3,73 +3,37 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 )
 
 func TestTitleConsumerConsume(t *testing.T) {
-	rules, err := RetrieveRules("fixtures/marc_rules.json")
-
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	marcfile, err := os.Open("fixtures/record1.mrc")
-	if err != nil {
-		t.Error(err)
-	}
-	done := make(chan bool, 1)
-	out := make(chan Record)
-
-	p := MarcParser{file: marcfile, rules: rules}
-	go p.Parse(out)
-
 	var b bytes.Buffer
-	consumer := &TitleConsumer{out: &b}
-	go consumer.Consume(out, done)
-
-	// wait until the ConsumeRecords routine reports it is done via `done` channel
-	<-done
-
-	if strings.TrimSpace(b.String()) != "Arithmetic /" {
-		t.Error("Expected match, got", b.String())
+	in := make(chan Record)
+	c := TitleConsumer{out: &b}
+	out := c.Consume(in)
+	in <- Record{Title: "Hatsopoulos Microfluids"}
+	close(in)
+	<-out
+	s := strings.TrimSpace(b.String())
+	if s != "Hatsopoulos Microfluids" {
+		t.Error("Expected match, got", s)
 	}
 }
 
 func TestTitleJsonConsume(t *testing.T) {
-	rules, err := RetrieveRules("fixtures/marc_rules.json")
-
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	marcfile, err := os.Open("fixtures/test.mrc")
-	if err != nil {
-		t.Error(err)
-	}
-	done := make(chan bool, 1)
-	out := make(chan Record)
-
-	p := MarcParser{file: marcfile, rules: rules}
-	go p.Parse(out)
-
 	var b bytes.Buffer
-	consumer := &JSONConsumer{out: &b}
-	go consumer.Consume(out, done)
-
-	// wait until the ConsumeRecords routine reports it is done via `done` channel
-	<-done
+	in := make(chan Record)
+	c := JSONConsumer{out: &b}
+	out := c.Consume(in)
+	in <- Record{Title: "Hatsopoulos Microfluids"}
+	close(in)
+	<-out
 
 	var records []*Record
 	json.NewDecoder(&b).Decode(&records)
 
-	if records[0].Title != "Diagnostic histochemistry" {
+	if records[0].Title != "Hatsopoulos Microfluids" {
 		t.Error("Expected match, got", records[0].Title)
-	}
-	if records[0].Identifier != "50001" {
-		t.Error("Expected match, got", records[0].Identifier)
 	}
 }

--- a/jsonrecord.go
+++ b/jsonrecord.go
@@ -10,7 +10,7 @@ type jsonparser struct {
 	file io.Reader
 }
 
-//JSONGenerator parses JSON-formatted MARC records.
+//JSONGenerator parses JSON records.
 type JSONGenerator struct {
 	file io.Reader
 }

--- a/jsonrecord.go
+++ b/jsonrecord.go
@@ -6,18 +6,16 @@ import (
 	"log"
 )
 
-type JSONParser struct {
+type jsonparser struct {
 	file io.Reader
 }
 
-type JSONProcessor struct {
-	file     io.Reader
-	consumer Consumer
-	out      chan Record
-	done     chan bool
+//JSONGenerator parses JSON-formatted MARC records.
+type JSONGenerator struct {
+	file io.Reader
 }
 
-func (j *JSONParser) Parse(out chan Record) {
+func (j *jsonparser) parse(out chan Record) {
 	ingested = 0
 	decoder := json.NewDecoder(j.file)
 
@@ -46,13 +44,10 @@ func (j *JSONParser) Parse(out chan Record) {
 	close(out)
 }
 
-func (j *JSONProcessor) Process() {
-	p := JSONParser{file: j.file}
-	go p.Parse(j.out)
-	go j.consumer.Consume(j.out, j.done)
-
-	// wait until the Consume routine reports `done` channel
-	<-j.done
-
-	log.Println("Ingested ", ingested, "records")
+//Generate creates a channel of Records.
+func (j *JSONGenerator) Generate() <-chan Record {
+	out := make(chan Record)
+	p := jsonparser{file: j.file}
+	go p.parse(out)
+	return out
 }

--- a/jsonrecord_test.go
+++ b/jsonrecord_test.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"bytes"
-	"log"
 	"os"
-	"strings"
 	"testing"
 )
 
@@ -16,11 +13,11 @@ func TestJsonParser(t *testing.T) {
 
 	out := make(chan Record)
 
-	p := JSONParser{file: jsonfile}
-	go p.Parse(out)
+	p := jsonparser{file: jsonfile}
+	go p.parse(out)
 
 	var chanLength int
-	for _ = range out {
+	for range out {
 		chanLength++
 	}
 
@@ -34,20 +31,14 @@ func TestJsonProcess(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	tmp := os.Stdout
-	os.Stdout, _ = os.Open(os.DevNull)
-	out := make(chan Record)
-	done := make(chan bool, 1)
 
-	consumer := &TitleConsumer{out: os.Stdout}
-	p := JSONProcessor{file: jsonfile, consumer: consumer, out: out, done: done}
-	p.Process()
+	var i int
+	p := JSONGenerator{file: jsonfile}
+	for range p.Generate() {
+		i++
+	}
 
-	log.SetOutput(os.Stderr)
-	os.Stdout = tmp
-	if !strings.Contains(buf.String(), "Ingested  1962 records") {
-		t.Error("Expected match, got", buf.String())
+	if i != 1962 {
+		t.Error("Expected match, got", i)
 	}
 }

--- a/marc_test.go
+++ b/marc_test.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"bytes"
-	"log"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -205,11 +202,11 @@ func TestMarcParser(t *testing.T) {
 
 	out := make(chan Record)
 
-	p := MarcParser{file: marcfile, rules: rules}
-	go p.Parse(out)
+	p := marcparser{file: marcfile, rules: rules}
+	go p.parse(out)
 
 	var chanLength int
-	for _ = range out {
+	for range out {
 		chanLength++
 	}
 
@@ -223,20 +220,13 @@ func TestMarcProcess(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	tmp := os.Stdout
-	os.Stdout, _ = os.Open(os.DevNull)
-	out := make(chan Record)
-	done := make(chan bool, 1)
-
-	consumer := &TitleConsumer{out: os.Stdout}
-	p := MarcProcessor{marcfile: marcfile, rulesfile: "fixtures/marc_rules.json", consumer: consumer, out: out, done: done}
-	p.Process()
-
-	log.SetOutput(os.Stderr)
-	os.Stdout = tmp
-	if !strings.Contains(buf.String(), "Ingested  85 records") {
-		t.Error("Expected match, got", buf.String())
+	p := MarcGenerator{marcfile: marcfile, rulesfile: "fixtures/marc_rules.json"}
+	out := p.Generate()
+	var i int
+	for range out {
+		i++
+	}
+	if i != 85 {
+		t.Error("Expected match, got", i)
 	}
 }

--- a/pipeline.go
+++ b/pipeline.go
@@ -1,0 +1,44 @@
+package main
+
+//A Pipeline builds and runs a data pipeline for process Records. A
+//Pipeline consists of exactly one Generator, one Consumer and zero or
+//more Transformers.
+type Pipeline struct {
+	generator    Generator
+	transformers []Transformer
+	consumer     Consumer
+}
+
+//The Transformer interface can be used to create an intermediate stage
+//in a Pipeline.
+type Transformer interface {
+	Transform(<-chan Record) <-chan Record
+}
+
+//The Generator interface should be used to create the initial stage of
+//a Pipeline.
+type Generator interface {
+	Generate() <-chan Record
+}
+
+//The Consumer interface should be used to create the last stage of a
+//Pipeline.
+type Consumer interface {
+	Consume(<-chan Record) <-chan bool
+}
+
+//Next adds one or more Transformers to the Pipeline. Next can be called
+//multiple times. All Transformers will be run in the order added.
+func (p *Pipeline) Next(t ...Transformer) {
+	p.transformers = append(p.transformers, t...)
+}
+
+//Run the Pipeline. Be sure to read from the empty channel that's returned
+//as that signals the Pipeline has finished running.
+func (p *Pipeline) Run() <-chan bool {
+	out := p.generator.Generate()
+	for _, t := range p.transformers {
+		out = t.Transform(out)
+	}
+	return p.consumer.Consume(out)
+}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"testing"
+)
+
+type Fooer struct{}
+
+func (f *Fooer) Transform(in <-chan Record) <-chan Record {
+	out := make(chan Record)
+	go func() {
+		for r := range in {
+			r.Title = r.Title + "FOO"
+			out <- r
+		}
+		close(out)
+	}()
+	return out
+}
+
+type RecordGenerator struct{}
+
+func (g *RecordGenerator) Generate() <-chan Record {
+	out := make(chan Record)
+	go func() {
+		out <- Record{Title: "Bar"}
+		out <- Record{Title: "Gaz"}
+		close(out)
+	}()
+	return out
+}
+
+type RecordConsumer struct {
+	records []Record
+}
+
+func (c *RecordConsumer) Consume(in <-chan Record) <-chan bool {
+	out := make(chan bool)
+	go func() {
+		for r := range in {
+			c.records = append(c.records, r)
+		}
+		close(out)
+	}()
+	return out
+}
+
+func TestRun(t *testing.T) {
+	c := &RecordConsumer{}
+	p := Pipeline{
+		generator: &RecordGenerator{},
+		consumer:  c,
+	}
+	p.Next(&Fooer{})
+	out := p.Run()
+	<-out
+	if c.records[0].Title != "BarFOO" {
+		t.Error("Expected match, got", c.records[0].Title)
+	}
+}


### PR DESCRIPTION
#### What does this PR do?

This commit primarily adds a Pipeline struct that handles construction
and execution of the Pipeline, along with three interfaces. A Pipeline
consists of a single Generator, zero or more Transformers and a single
Consumer.

The main goal was to decouple the pipeline functionality from the
parsers, which is where it was living. The pipeline is now entirely
created and run by main, and none of the parsers or consumers even know
about the pipeline.

The other big change is to the pipeline itself handle hooking up
channels between stages. It's no longer necessary to create any channels
up front. The pipeline's Run() method will return an empty channel that
can be read from to determine when the pipeline has completed.

This decoupling makes the test setup considerably easier. Slotting in
new Generators, Transformers and Consumers should only require minimal
changes to main going forward.

#### How can a reviewer manually see the effects of these changes?

This is a refactor, so there are no new changes to functionality. Running `go test` should be enough to verify the changes.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-143

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
