### PR TITLE
Allow configuration of ES at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@
 Mario is a metadata processing pipeline that will process data from various
 sources and write to Elasticsearch.
 
+## How to Use This
+
+An Elasticsearch index can be started for development purposes by running:
+
+```
+$ docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" \
+    docker.elastic.co/elasticsearch/elasticsearch:6.4.2
+```
+
+Create and configure the index with:
+
+```
+$ mario create
+```
+
 ## System Overview
 ![alt text](docs/charts/dip_overview.png "Mario system overview chart")
 

--- a/main.go
+++ b/main.go
@@ -73,7 +73,9 @@ func main() {
 					url := c.String("url")
 					index := c.String("index")
 
-					client, err := elastic.NewClient(elastic.SetURL(url))
+					client, err := elastic.NewClient(
+						elastic.SetURL(url),
+						elastic.SetSniff(false))
 					if err != nil {
 						return err
 					}
@@ -120,7 +122,9 @@ func main() {
 			Action: func(c *cli.Context) error {
 				url := c.String("url")
 				index := c.String("index")
-				client, err := elastic.NewClient(elastic.SetURL(url))
+				client, err := elastic.NewClient(
+					elastic.SetURL(url),
+					elastic.SetSniff(false))
 				if err != nil {
 					return err
 				}

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 
@@ -15,6 +14,7 @@ func main() {
 	app.Commands = []cli.Command{
 		{
 			Name:      "parse",
+			Usage:     "Parse and ingest the input file",
 			ArgsUsage: "[filepath or - to use stdin]",
 			Flags: []cli.Flag{
 				cli.StringFlag{
@@ -25,12 +25,22 @@ func main() {
 				cli.StringFlag{
 					Name:  "consumer, c",
 					Value: "es",
-					Usage: "Consumer to use (es, json or title; default is es)",
+					Usage: "Consumer to use (es, json or title)",
 				},
 				cli.StringFlag{
 					Name:  "type, t",
 					Value: "marc",
-					Usage: "Type of file to process (default is marc)",
+					Usage: "Type of file to process",
+				},
+				cli.StringFlag{
+					Name:  "url, u",
+					Value: "http://127.0.0.1:9200",
+					Usage: "URL for the Elasticsearch cluster",
+				},
+				cli.StringFlag{
+					Name:  "index, i",
+					Value: "timdex",
+					Usage: "Name of the Elasticsearch index",
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -54,12 +64,16 @@ func main() {
 
 				p := Pipeline{}
 
+				//Configure the pipeline consumer
 				if c.String("consumer") == "json" {
 					p.consumer = &JSONConsumer{out: os.Stdout}
 				} else if c.String("consumer") == "title" {
 					p.consumer = &TitleConsumer{out: os.Stdout}
 				} else {
-					client, err := elastic.NewSimpleClient()
+					url := c.String("url")
+					index := c.String("index")
+
+					client, err := elastic.NewClient(elastic.SetURL(url))
 					if err != nil {
 						return err
 					}
@@ -68,9 +82,10 @@ func main() {
 						return err
 					}
 					defer es.Close()
-					p.consumer = &ESConsumer{Index: "timdex", RType: "marc", p: es}
+					p.consumer = &ESConsumer{Index: index, RType: "marc", p: es}
 				}
 
+				//Configure the pipeline input
 				if c.String("type") == "marc" {
 					p.generator = &MarcGenerator{
 						marcfile:  file,
@@ -88,27 +103,35 @@ func main() {
 			},
 		},
 		{
-			Name: "create",
+			Name:  "create",
+			Usage: "Create an Elasticsearch index",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "url, u",
+					Value: "http://127.0.0.1:9200",
+					Usage: "URL for the Elasticsearch cluster",
+				},
+				cli.StringFlag{
+					Name:  "index, i",
+					Value: "timdex",
+					Usage: "Name of the Elasticsearch index",
+				},
+			},
 			Action: func(c *cli.Context) error {
-				client, err := elastic.NewSimpleClient()
+				url := c.String("url")
+				index := c.String("index")
+				client, err := elastic.NewClient(elastic.SetURL(url))
 				if err != nil {
 					return err
 				}
 				ctx := context.Background()
-				created, err := client.CreateIndex("timdex").Do(ctx)
+				_, err = client.CreateIndex(index).Do(ctx)
 				if err != nil {
 					return err
-				}
-				if !created.Acknowledged {
-					fmt.Println("Elasticsearch couldn't create the index")
 				}
 				return nil
 			},
 		},
-	}
-	app.Action = func(c *cli.Context) error {
-		fmt.Println("Reserved for λ")
-		return nil
 	}
 
 	err := app.Run(os.Args)


### PR DESCRIPTION
This removes the hardcoded values for the Elasticsearch URL and index.
They can now be specified at the CLI and will fall back to defaults if
not given.

#### How can a reviewer manually see the effects of these changes?

Map a non-default port when starting the docker image:

```
$ docker run -p 9201:9200 -p 9300:9300 -e "discovery.type=single-node" \
    docker.elastic.co/elasticsearch/elasticsearch:6.4.2
$ mario create --url http://127.0.0.1:9201 --index foobar
```

Then go to http://127.0.0.1:9201/foobar in your browser.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-143

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
