### PR TITLE
Add record counter

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,8 @@ import (
 )
 
 func main() {
+	var debug bool
+
 	app := cli.NewApp()
 	app.Commands = []cli.Command{
 		{
@@ -41,6 +43,11 @@ func main() {
 					Name:  "index, i",
 					Value: "timdex",
 					Usage: "Name of the Elasticsearch index",
+				},
+				cli.BoolFlag{
+					Name:        "debug",
+					Usage:       "Output debugging information",
+					Destination: &debug,
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -99,8 +106,16 @@ func main() {
 					log.Println("no valid type provided")
 				}
 
+				ctr := &Counter{}
+				p.Next(ctr)
+
 				out := p.Run()
 				<-out
+
+				if debug {
+					log.Printf("Total records ingested: %d", ctr.Count)
+				}
+
 				return nil
 			},
 		},

--- a/transformers.go
+++ b/transformers.go
@@ -1,0 +1,19 @@
+package main
+
+//Counter transformer records the number of records handled.
+type Counter struct {
+	Count int
+}
+
+//Transform counts the records.
+func (c *Counter) Transform(in <-chan Record) <-chan Record {
+	out := make(chan Record)
+	go func() {
+		for r := range in {
+			c.Count++
+			out <- r
+		}
+		close(out)
+	}()
+	return out
+}

--- a/transformers_test.go
+++ b/transformers_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestCounterTransform(t *testing.T) {
+	in := make(chan Record, 2)
+	in <- Record{Title: "Foo"}
+	in <- Record{Title: "Bar"}
+	close(in)
+	c := Counter{}
+	out := c.Transform(in)
+	<-out
+	if c.Count != 2 {
+		t.Error("Expected match, got", c.Count)
+	}
+}


### PR DESCRIPTION
#### What does this PR do?

This adds a simple transformer that counts the number of records
ingested. The Counter transformer has a count attribute that can be read
after the pipeline has finished. A debug flag has been added to print
this information.
#### How can a reviewer manually see the effects of these changes?

`$ mario parse -c title --debug fixtures/test.mrc`

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
