### PR TITLE
Declare Record names for indexing

### DIFF
--- a/consumers.go
+++ b/consumers.go
@@ -21,7 +21,11 @@ func (es *ESConsumer) Consume(in <-chan Record) <-chan bool {
 	out := make(chan bool)
 	go func() {
 		for r := range in {
-			d := elastic.NewBulkIndexRequest().Index(es.Index).Type(es.RType).Doc(r)
+			d := elastic.NewBulkIndexRequest().
+				Index(es.Index).
+				Id(r.Identifier).
+				Type(es.RType).
+				Doc(r)
 			es.p.Add(d)
 		}
 		close(out)

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func main() {
 						return err
 					}
 					defer es.Close()
-					p.consumer = &ESConsumer{Index: index, RType: "marc", p: es}
+					p.consumer = &ESConsumer{Index: index, RType: "Record", p: es}
 				}
 
 				//Configure the pipeline input

--- a/marc.go
+++ b/marc.go
@@ -103,15 +103,6 @@ func marcToRecord(marcRecord *marc21.Record, rules []*Rule, languageCodes map[st
 
 	r.InBibliography = getFields(marcRecord, rules, "in_bibliography")
 
-	// urls 856:4[0|1] $u
-	// only take 856 fields where first indicator is 4
-	// only take 856 fields where second indicator is 0 or 1
-	// possibly filter out any matches where $3 or $z is "table of contents" or "Publisher description"
-	// todo: this does not follow the noted rules yet and instead just grabs anything in 856$u
-	// r.url = getFields(marcRecord, rules, "url")
-
-	// TODO: Links may be best represented by extracting a few values from 856 and _not_ contatanating them but instead filtering on some values and storing them in the Link structs
-
 	r.Subject = getFields(marcRecord, rules, "subjects")
 
 	r.Isbn = getFields(marcRecord, rules, "isbns")

--- a/marc_test.go
+++ b/marc_test.go
@@ -141,10 +141,6 @@ func TestMarcToRecord(t *testing.T) {
 		t.Error("Expected match, got", item.Subject[0])
 	}
 
-	if item.URL != nil {
-		t.Error("Expected no matches, got", item.URL)
-	}
-
 	if item.PublicationDate != "1993" {
 		t.Error("Expected match, got", item.PublicationDate)
 	}

--- a/record.go
+++ b/record.go
@@ -3,65 +3,64 @@ package main
 // Record struct stores our internal mappings of data and is used to when
 // mapping various external data sources before sending to elasticsearch
 type Record struct {
-	Identifier           string
-	Title                string
-	AlternateTitles      []string
-	Creator              []string
-	Contributor          []*Contributor
-	URL                  []string
-	Subject              []string
-	Isbn                 []string
-	Issn                 []string
-	Doi                  []string
-	OclcNumber           []string
-	Lccn                 string
-	Country              string
-	Language             []string
-	PublicationDate      string
-	ContentType          string
-	CallNumber           []string
-	Edition              string
-	Imprint              []string
-	PhysicalDescription  string
-	PublicationFrequency []string
-	Numbering            string
-	Notes                []string
-	Contents             []string
-	Summary              []string
-	Format               []string
-	LiteraryForm         string
-	RelatedPlace         []string
-	InBibliography       []string
-	RelatedItems         []*RelatedItem
-	Links                []Link
-	Holdings             []Holdings
+	Identifier           string         `json:"identifier"`
+	Title                string         `json:"title"`
+	AlternateTitles      []string       `json:"alternate_titles,omitempty"`
+	Creator              []string       `json:"creators,omitempty"`
+	Contributor          []*Contributor `json:"contributors,omitempty"`
+	Subject              []string       `json:"subjects,omitempty"`
+	Isbn                 []string       `json:"isbns,omitempty"`
+	Issn                 []string       `json:"issns,omitempty"`
+	Doi                  []string       `json:"dois,omitempty"`
+	OclcNumber           []string       `json:"oclcs,omitempty"`
+	Lccn                 string         `json:"lccn,omitempty"`
+	Country              string         `json:"country_of_publication,omitempty"`
+	Language             []string       `json:"languages,omitempty"`
+	PublicationDate      string         `json:"publication_date,omitempty"`
+	ContentType          string         `json:"content_type,omitempty"`
+	CallNumber           []string       `json:"call_numbers,omitempty"`
+	Edition              string         `json:"edition,omitempty"`
+	Imprint              []string       `json:"imprint,omitempty"`
+	PhysicalDescription  string         `json:"physical_description,omitempty"`
+	PublicationFrequency []string       `json:"publication_frequency,omitempty"`
+	Numbering            string         `json:"numbering,omitempty"`
+	Notes                []string       `json:"notes,omitempty"`
+	Contents             []string       `json:"contents,omitempty"`
+	Summary              []string       `json:"summary,omitempty"`
+	Format               []string       `json:"format,omitempty"`
+	LiteraryForm         string         `json:"literary_form,omitempty"`
+	RelatedPlace         []string       `json:"related_place,omitempty"`
+	InBibliography       []string       `json:"in_bibliography,omitempty"`
+	RelatedItems         []*RelatedItem `json:"related_items,omitempty"`
+	Links                []Link         `json:"links,omitempty"`
+	Holdings             []Holdings     `json:"holdings,omitempty"`
 }
 
 // Contributor is a port of a Record
 type Contributor struct {
-	Kind  string
-	Value []string
+	Kind  string   `json:"kind"`
+	Value []string `json:"value"`
 }
 
 // RelatedItem is a port of a Record
 type RelatedItem struct {
-	Kind  string
-	Value []string
+	Kind  string   `json:"kind"`
+	Value []string `json:"value"`
 }
 
 // Link is a port of a Record
 type Link struct {
-	Kind         string
-	Text         string
-	URL          string
-	Restrictions string
+	Kind         string `json:"kind"`
+	Text         string `json:"text"`
+	URL          string `json:"url"`
+	Restrictions string `json:"restrictions"`
 }
 
 // Holdings is a port of a Record
 type Holdings struct {
-	Location   string
-	CallNumber string
-	Status     string
+	Location   string `json:"location"`
+	CallNumber string `json:"call_number"`
+	Status     string `json:"status"`
 }
 
 // Rule defines where the rules are in JSON


### PR DESCRIPTION
#### What does this PR do?

Adds consistent elasticsearch `_id` so reindexing will overwrite a record and not add a new one.

This also adds support for the naming we expect on the API side. This isn't strictly necessary, but I think it will be helpful for debugging purposes in the future if the elasticsearch has the same fieldnames as the API responses. As such, this is part of DIP-164.

This removes `Record.URL` as we will be handling that as part of Record.Links.

#### Helpful background context

This does not create index mappings which is the crux of what DIP-167 needs to do so this does not close the ticket even if at first look they appear related.

#### How can a reviewer manually see the effects of these changes?

Drop your timdex index and index some stuff. The field names will now be lowercase and match our spreadsheet. Additionally, if you index the same content again at this stage you will not double the number of records in the index because of the consistent `_id` now being used.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-164 (this allows that work to complete)
- https://mitlibraries.atlassian.net/browse/DIP-167 (sort of)

#### Requires Full Reindexing of all Sources?
YES

#### Includes new or updated dependencies?
NO
