### PR TITLE
Adds Source and SourceLink

### DIFF
--- a/marc.go
+++ b/marc.go
@@ -82,6 +82,8 @@ func marcToRecord(marcRecord *marc21.Record, rules []*Rule, languageCodes map[st
 	r := Record{}
 
 	r.Identifier = marcRecord.Identifier()
+	r.Source = "MIT Aleph"
+	r.SourceLink = "https://library.mit.edu/item/" + r.Identifier
 	r.OclcNumber = getFields(marcRecord, rules, "oclc_number")
 
 	lccn := getFields(marcRecord, rules, "lccn")

--- a/record.go
+++ b/record.go
@@ -4,6 +4,8 @@ package main
 // mapping various external data sources before sending to elasticsearch
 type Record struct {
 	Identifier           string         `json:"identifier"`
+	Source               string         `json:"source"`
+	SourceLink           string         `json:"source_link"`
 	Title                string         `json:"title"`
 	AlternateTitles      []string       `json:"alternate_titles,omitempty"`
 	Creator              []string       `json:"creators,omitempty"`


### PR DESCRIPTION
#### What does this PR do?

Adds `Record.Source` and `Record.SourceLink`. The Source is primarily a debugging bit for the future. The latter is necessary to provide in the API and I was initially going to construct it as needed as part of API logic but this seems probably better overall to construct these links during ingest and leave the API as loosely coupled as we can to the actual sources.

#### Requires Full Reindexing of all Sources?
YES

#### Includes new or updated dependencies?
NO
