### PR TITLE
Elasticsearch Record index configuration

### DIFF
--- a/config/es_record_mappings.json
+++ b/config/es_record_mappings.json
@@ -1,0 +1,204 @@
+{
+	"mappings": {
+		"Record": {
+			"properties": {
+				"alternate_titles" : {
+					 "type" : "text"
+				},
+				"call_numbers": {
+					"type": "text"
+				},
+				"content_type": {
+					"type": "text",
+					"fields": {
+						"keyword": {
+							"type": "keyword",
+							"ignore_above": 256
+						}
+					}
+				},
+				"contents" : {
+					"type" : "text"
+				},
+				"contributors": {
+					"properties": {
+						"kind": {
+							"type": "text",
+							"fields": {
+								"keyword": {
+									"type": "keyword",
+									"ignore_above": 256
+								}
+							}
+						},
+						"value": {
+							"type": "text",
+							"fields": {
+								"keyword": {
+									"type": "keyword",
+									"ignore_above": 256
+								}
+							}
+						}
+					}
+				},
+				"country_of_publication": {
+					"type": "text",
+					"fields": {
+						"keyword": {
+							"type": "keyword",
+							"ignore_above": 256
+						}
+					}
+				},
+				"creators": {
+					"type": "text",
+					"fields": {
+						"keyword": {
+							"type": "keyword",
+							"ignore_above": 256
+						}
+					}
+				},
+				"dois" : {
+					"type" : "text"
+				},
+				"edition": {
+					"type": "text"
+				},
+				"format" : {
+					"type" : "text",
+					"fields" : {
+						"keyword" : {
+							"type" : "keyword",
+							"ignore_above" : 256
+						}
+					}
+				},
+				"identifier": {
+					"type": "text"
+				},
+				"imprint": {
+					"type": "text"
+				},
+				"isbns": {
+					"type": "text"
+				},
+				"languages": {
+					"type": "text",
+					"fields": {
+						"keyword": {
+							"type": "keyword",
+							"ignore_above": 256
+						}
+					}
+				},
+				"lccn": {
+					"type": "text",
+					"fields": {
+						"keyword": {
+							"type": "keyword",
+							"ignore_above": 256
+						}
+					}
+				},
+				"literary_form": {
+					"type": "text",
+					"fields": {
+						"keyword": {
+							"type": "keyword",
+							"ignore_above": 256
+						}
+					}
+				},
+				"notes": {
+					"type": "text"
+				},
+				"numbering" : {
+					"type" : "text"
+				},
+				"oclcs" : {
+					"type" : "text"
+				},
+				"physical_description": {
+					"type": "text"
+				},
+				"publication_date": {
+					"type": "text",
+					"fields": {
+						"date": {
+							"type": "date"
+						}
+					}
+				},
+				"publication_frequency" : {
+					"type" : "text",
+					"fields" : {
+						"keyword" : {
+							"type" : "keyword",
+							"ignore_above" : 256
+						}
+					}
+				},
+				"related_items" : {
+					"properties" : {
+						"kind" : {
+							"type" : "text",
+							"fields" : {
+								"keyword" : {
+									"type" : "keyword",
+									"ignore_above" : 256
+								}
+							}
+						},
+						"value" : {
+							"type" : "text",
+							"fields" : {
+								"keyword" : {
+									"type" : "keyword",
+									"ignore_above" : 256
+								}
+							}
+						}
+					}
+				},
+				"related_place" : {
+					"type" : "text",
+					"fields" : {
+						"keyword" : {
+							"type" : "keyword",
+							"ignore_above" : 256
+						}
+					}
+				},
+				"source": {
+					"type": "text",
+					"fields": {
+						"keyword": {
+							"type": "keyword",
+							"ignore_above": 256
+						}
+					}
+				},
+				"source_link": {
+					"type": "text"
+				},
+				"subjects": {
+					"type": "text",
+					"fields": {
+						"keyword": {
+							"type": "keyword",
+							"ignore_above": 256
+						}
+					}
+				},
+				"summary": {
+					"type": "text"
+				},
+				"title": {
+					"type": "text"
+				}
+			}
+		}
+	}
+}

--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/olivere/elastic"
+	aws "github.com/olivere/elastic/aws/v4"
+)
+
+// EsClient configures the elasticsearch client
+func esClient(url string, index string, v4 bool) (*elastic.Client, error) {
+	var client *http.Client
+	if v4 {
+		sess := session.Must(session.NewSession())
+		creds := credentials.NewChainCredentials([]credentials.Provider{
+			&credentials.EnvProvider{},
+			&credentials.SharedCredentialsProvider{},
+			&ec2rolecreds.EC2RoleProvider{
+				Client: ec2metadata.New(sess),
+			},
+		})
+		client = aws.NewV4SigningClient(creds, "us-east-1")
+	} else {
+		client = http.DefaultClient
+	}
+	return elastic.NewClient(
+		elastic.SetURL(url),
+		elastic.SetSniff(false),
+		elastic.SetHealthcheck(false),
+		elastic.SetHttpClient(client),
+	)
+}
+
+// CreateRecordIndex creates our Record index
+func createRecordIndex(client *elastic.Client, index string) error {
+	mappings, err := ioutil.ReadFile("config/es_record_mappings.json")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background()
+	_, err = client.CreateIndex(index).BodyString(string(mappings)).Do(ctx)
+	if err != nil {
+		panic(err)
+	}
+	log.Println("Index created")
+	return nil
+}


### PR DESCRIPTION
#### What does this PR do?

Most of this configuration was taken from an auto generated index. I've changed some fields to text instead of keyword that I think make sense. Others may want adjustments later. `ignore_above` value probably needs some analysis.

To ensure we always use these rules for creating an index, we check for index existance in the Parse command and create one if it doesn't exist. Otherwise, one is automatically created for us based on the Record struct in go which isn't exactly what we want here.

This also starts to move some es config to a config package as our main.go. This will likely get more work after https://mitlibraries.atlassian.net/browse/DIP-169.

#### How can a reviewer manually see the effects of these changes?

Create an index and view it. One particularly difference you can note between the auto generated config and this one is the `publication_date` is now a `date` and not `text`.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-167

#### Requires Full Reindexing of all Sources?
YES

#### Includes new or updated dependencies?
NO
