### PR TITLE
Deal with remaining empty fields in output from MARC records

### DIFF
--- a/marc_test.go
+++ b/marc_test.go
@@ -118,7 +118,7 @@ func TestMarcToRecord(t *testing.T) {
 		return
 	}
 
-	item := marcToRecord(record, rules, languageCodes)
+	item, _ := marcToRecord(record, rules, languageCodes)
 
 	if item.Creator[0] != "Sandburg, Carl, 1878-1967." {
 		t.Error("Expected match, got", item.Creator)


### PR DESCRIPTION
#### What does this PR do?

Removes empty language fields from record in MARC parser.
Logs error if MARC record has no title (this is an indication of an invalid record).

#### How can a reviewer manually see the effects of these changes?

Run MARC parser with JSON consumer on test record set. There will no longer be empty strings in the languages arrays.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-168

#### Requires Full Reindexing of all Sources?
YES

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
