### PR TITLE
Adds Summary Holdings

### DIFF
--- a/config/es_record_mappings.json
+++ b/config/es_record_mappings.json
@@ -75,6 +75,22 @@
 						}
 					}
 				},
+				"holdings": {
+					"properties": {
+						"call_number": {
+							"type": "keyword"
+						},
+						"location": {
+							"type": "keyword"
+						},
+						"notes": {
+							"type": "text"
+						},
+						"summary": {
+							"type": "text"
+						}
+					}
+				},
 				"identifier": {
 					"type": "text"
 				},

--- a/config/marc_rules.json
+++ b/config/marc_rules.json
@@ -490,5 +490,16 @@
         "notes": "For this field, if indicator 1 is 4 and indicator 2 is 0 or 1, we take the URL from subfield u, the kind from subfield 3, link text from subfield y, and restrictions from subfield z."
       }
     ]
+  },
+  {
+    "label": "holdings_locations",
+    "array": true,
+    "fields": [
+      {
+        "tag": "866",
+        "subfields": "bcha",
+        "notes": "We can't use our normal rule parsing for this as we need to split the subfields into a structure in a way that doesn't fit our normal expectations."
+      }
+    ]
   }
 ]

--- a/marc.go
+++ b/marc.go
@@ -172,6 +172,7 @@ func marcToRecord(marcRecord *marc21.Record, rules []*Rule, languageCodes map[st
 	r.LiteraryForm = literaryForm(lf)
 
 	r.Links = getLinks(marcRecord)
+	r.Holdings = getHoldings(marcRecord)
 
 	return r, err
 }
@@ -369,7 +370,7 @@ func TranslateLanguageCodes(recordCodes []string, languageCodes map[string]strin
 	return languages
 }
 
-// getLinks take a MARC record and eturns an array of Link objects from the 856 field data.
+// getLinks take a MARC record and returns an array of Link objects from the 856 field data.
 func getLinks(marcrecord *marc21.Record) []Link {
 	var links []Link
 	marc856 := marcrecord.GetFields("856")
@@ -393,4 +394,25 @@ func getLinks(marcrecord *marc21.Record) []Link {
 		}
 	}
 	return links
+}
+
+// getHoldings takes a MARC record and returns an array of Holdings objects
+func getHoldings(marcrecord *marc21.Record) []Holding {
+	var holdings []Holding
+	marc866 := marcrecord.GetFields("866")
+	if len(marc866) == 0 {
+		return nil
+	}
+	for _, f := range marc866 {
+		switch f := f.(type) {
+		case *marc21.DataField:
+			holding := Holding{
+				Location:   stringifySelectSubfields(f, []byte("bc")),
+				CallNumber: stringifySelectSubfields(f, []byte("h")),
+				Summary:    stringifySelectSubfields(f, []byte("a")),
+				Notes:      stringifySelectSubfields(f, []byte("z"))}
+			holdings = append(holdings, holding)
+		}
+	}
+	return holdings
 }

--- a/record.go
+++ b/record.go
@@ -35,7 +35,7 @@ type Record struct {
 	InBibliography       []string       `json:"in_bibliography,omitempty"`
 	RelatedItems         []*RelatedItem `json:"related_items,omitempty"`
 	Links                []Link         `json:"links,omitempty"`
-	Holdings             []Holdings     `json:"holdings,omitempty"`
+	Holdings             []Holding      `json:"holdings,omitempty"`
 }
 
 // Contributor is a port of a Record
@@ -59,10 +59,11 @@ type Link struct {
 }
 
 // Holdings is a port of a Record
-type Holdings struct {
+type Holding struct {
 	Location   string `json:"location"`
 	CallNumber string `json:"call_number"`
-	Status     string `json:"status"`
+	Summary    string `json:"summary"`
+	Notes      string `json:"notes"`
 }
 
 // Rule defines where the rules are in JSON


### PR DESCRIPTION
#### What does this PR do?

Indexes summary holdings from 866 if it exists.

#### Helpful background context

Not all of our records have an 866 field, but the ones that do are the best place to get this information. Monograph records, including serial monographs will not have 866. Most serials should have an 866 in our records.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-194

#### Requires Full Reindexing of all Sources?
YES

#### Includes new or updated dependencies?
NO
