### PR TITLE
Add content_type now that fml support it

### DIFF
--- a/marc.go
+++ b/marc.go
@@ -163,8 +163,7 @@ func marcToRecord(fmlRecord fml.Record, rules []*Rule, languageCodes map[string]
 	// TODO: use lookup tables to translate returned codes to values
 	r.Format = applyRule(fmlRecord, rules, "format")
 
-	// TODO: use lookup tables to translate returned codes to values
-	// r.ContentType = contentType(fmlRecord.Leader.Type)
+	r.ContentType = contentType(fmlRecord.Leader.Type)
 
 	lf := applyRule(fmlRecord, rules, "literary_form")
 	r.LiteraryForm = literaryForm(lf)


### PR DESCRIPTION
#### What does this PR do?

Adds content_type back to our Records now that fml supports leader elements.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-206

#### Requires Full Reindexing of all Sources?
YES

#### Includes new or updated dependencies?
NO
