### PR TITLE
Add lowercase filter to keyword fields

### DIFF
--- a/config/es_record_mappings.json
+++ b/config/es_record_mappings.json
@@ -1,4 +1,14 @@
 {
+  "settings": {
+    "analysis": {
+      "normalizer": {
+        "lowercase": {
+          "type": "custom",
+          "filter": ["lowercase"]
+        }
+      }
+    }
+  },
 	"mappings": {
 		"Record": {
 			"properties": {
@@ -13,6 +23,7 @@
 					"fields": {
 						"keyword": {
 							"type": "keyword",
+              "normalizer": "lowercase",
 							"ignore_above": 256
 						}
 					}
@@ -27,6 +38,7 @@
 							"fields": {
 								"keyword": {
 									"type": "keyword",
+                  "normalizer": "lowercase",
 									"ignore_above": 256
 								}
 							}
@@ -36,6 +48,7 @@
 							"fields": {
 								"keyword": {
 									"type": "keyword",
+                  "normalizer": "lowercase",
 									"ignore_above": 256
 								}
 							}
@@ -47,6 +60,7 @@
 					"fields": {
 						"keyword": {
 							"type": "keyword",
+              "normalizer": "lowercase",
 							"ignore_above": 256
 						}
 					}
@@ -56,6 +70,7 @@
 					"fields": {
 						"keyword": {
 							"type": "keyword",
+              "normalizer": "lowercase",
 							"ignore_above": 256
 						}
 					}
@@ -71,6 +86,7 @@
 					"fields" : {
 						"keyword" : {
 							"type" : "keyword",
+              "normalizer": "lowercase",
 							"ignore_above" : 256
 						}
 					}
@@ -89,6 +105,7 @@
 					"fields": {
 						"keyword": {
 							"type": "keyword",
+              "normalizer": "lowercase",
 							"ignore_above": 256
 						}
 					}
@@ -98,6 +115,7 @@
 					"fields": {
 						"keyword": {
 							"type": "keyword",
+              "normalizer": "lowercase",
 							"ignore_above": 256
 						}
 					}
@@ -107,6 +125,7 @@
 					"fields": {
 						"keyword": {
 							"type": "keyword",
+              "normalizer": "lowercase",
 							"ignore_above": 256
 						}
 					}
@@ -136,6 +155,7 @@
 					"fields" : {
 						"keyword" : {
 							"type" : "keyword",
+              "normalizer": "lowercase",
 							"ignore_above" : 256
 						}
 					}
@@ -147,6 +167,7 @@
 							"fields" : {
 								"keyword" : {
 									"type" : "keyword",
+                  "normalizer": "lowercase",
 									"ignore_above" : 256
 								}
 							}
@@ -156,6 +177,7 @@
 							"fields" : {
 								"keyword" : {
 									"type" : "keyword",
+                  "normalizer": "lowercase",
 									"ignore_above" : 256
 								}
 							}
@@ -167,6 +189,7 @@
 					"fields" : {
 						"keyword" : {
 							"type" : "keyword",
+              "normalizer": "lowercase",
 							"ignore_above" : 256
 						}
 					}
@@ -176,6 +199,7 @@
 					"fields": {
 						"keyword": {
 							"type": "keyword",
+              "normalizer": "lowercase",
 							"ignore_above": 256
 						}
 					}
@@ -188,6 +212,7 @@
 					"fields": {
 						"keyword": {
 							"type": "keyword",
+              "normalizer": "lowercase",
 							"ignore_above": 256
 						}
 					}


### PR DESCRIPTION
#### What does this PR do?

This adds a lowercase filter to all of our keyword fields.

In general capitalization shouldn't matter for keyword fields. Since the
filter is applied both by the indexer and the query parser the change
shouldn't affect anything that's currently using capitalization. It will
provide for a less frustrating experience if your capitalization is off,
though.

#### How can a reviewer manually see the effects of these changes?

The easiest way to see the change will be to ingest the fixture records without this change and do a search for `content_type.keyword:"cartographic material"`. This should return no results. If you then reingest with these changes the same search should return results whose content type shows as "Cartographic material".

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-178

#### Requires Full Reindexing of all Sources?
YES

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
