### PR TITLE
Add S3 object input loading to ingest command

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,7 +10,7 @@
   revision = "a79082be5fac8291d39578f5ee5641ea0e660e8e"
 
 [[projects]]
-  digest = "1:99d4347651f425801502c37cec85b4f0e211fbe64ed65311f0c9ae6bf585ec42"
+  digest = "1:d41cff10314da0d12d0e09d474eb20a9e327b0f30cd359886ccae53ae509047f"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -32,15 +32,20 @@
     "aws/session",
     "aws/signer/v4",
     "internal/ini",
+    "internal/s3err",
     "internal/sdkio",
     "internal/sdkrand",
     "internal/sdkuri",
     "internal/shareddefaults",
     "private/protocol",
+    "private/protocol/eventstream",
+    "private/protocol/eventstream/eventstreamapi",
     "private/protocol/query",
     "private/protocol/query/queryutil",
     "private/protocol/rest",
+    "private/protocol/restxml",
     "private/protocol/xml/xmlutil",
+    "service/s3",
     "service/sts",
   ]
   pruneopts = "UT"
@@ -109,10 +114,12 @@
   analyzer-version = 1
   input-imports = [
     "github.com/MITLibraries/fml",
+    "github.com/aws/aws-sdk-go/aws",
     "github.com/aws/aws-sdk-go/aws/credentials",
     "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
     "github.com/aws/aws-sdk-go/aws/ec2metadata",
     "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/s3",
     "github.com/davecgh/go-spew/spew",
     "github.com/olivere/elastic",
     "github.com/olivere/elastic/aws/v4",

--- a/s3.go
+++ b/s3.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"io"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+func getS3Obj(bucket string, key string) (io.ReadCloser, error) {
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String("us-east-1")},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	svc := s3.New(sess)
+
+	input := &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	}
+
+	result, err := svc.GetObject(input)
+	if err != nil {
+		return nil, err
+	}
+
+	return result.Body, err
+
+}


### PR DESCRIPTION
#### What does this PR do?

Adds ability to load a file from S3 to the ingest command. Also removes option to use stdin as input, for which we don't currently have a use case.

#### Helpful background context

Like the existing ES functionality, assumes AWS credentials are configured in the environment.

#### How can a reviewer manually see the effects of these changes?

Ingest a marc file from S3, providing an S3 file path argument (e.g., ```mario ingest s3://my-bucket/my-object```)

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-211

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
YES

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
