### PR TITLE
Support both full automatic and daily update modes

### DIFF
--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
@@ -51,5 +53,109 @@ func createRecordIndex(client *elastic.Client, index string) error {
 		panic(err)
 	}
 	log.Println("Index created")
+	return nil
+}
+
+func previous(client *elastic.Client, prefix string) ([]string, error) {
+	// retrieve all indexes linked to production alias and filter by supplied prefix. These are the "old" indexes.
+	log.Printf("previous!")
+	aliases, err := aliases(client)
+	if err != nil {
+		return nil, err
+	}
+
+	var indexes []string
+
+	for _, a := range aliases {
+		if strings.HasPrefix(a.Index, prefix) {
+			indexes = append(indexes, a.Index)
+		}
+	}
+
+	if len(aliases) == 0 {
+		fmt.Printf("No aliases found. Nothing to demote.")
+	}
+
+	log.Println(indexes)
+
+	return indexes, nil
+}
+
+func aliases(client *elastic.Client) (elastic.CatAliasesResponse, error) {
+	ctx := context.Background()
+	aliases, err := client.CatAliases().Do(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return aliases, nil
+}
+
+func delete(client *elastic.Client, index string) error {
+	ctx := context.Background()
+	_, err := client.DeleteIndex(index).Do(ctx)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Index deleted")
+	return nil
+}
+
+func demote(client *elastic.Client, index string) error {
+	ctx := context.Background()
+	_, err := client.Alias().Remove(index, "production").Do(ctx)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Index %s demoted.", index)
+	return nil
+}
+
+func indexes(client *elastic.Client) error {
+	ctx := context.Background()
+	indexes, err := client.CatIndices().Do(ctx)
+	if err != nil {
+		return err
+	}
+	for _, i := range indexes {
+		fmt.Printf("Name: %s \n"+
+			"  DocsCount: %d \n"+
+			"  Health: %s \n"+
+			"  Status: %s \n"+
+			"  UUID: %s \n"+
+			"  StoreSize: %s \n\n",
+			i.Index, i.DocsCount, i.Health, i.Status, i.UUID, i.StoreSize)
+	}
+	if len(indexes) == 0 {
+		fmt.Printf("No indexes found.")
+	}
+	return nil
+}
+
+func ping(client *elastic.Client, url string) error {
+	ctx := context.Background()
+	ping, code, err := client.Ping(url).Do(ctx)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Response code: %d \n"+
+		"Name: %s \n"+
+		"Cluster Name: %s \n"+
+		"Tag line: %s \n"+
+		"Version: %s \n"+
+		"BuildHash: %s \n"+
+		"LuceneVersion: %s \n",
+		code, ping.Name, ping.ClusterName, ping.TagLine, ping.Version.Number,
+		ping.Version.BuildHash, ping.Version.LuceneVersion)
+	return nil
+}
+
+func promote(client *elastic.Client, index string) error {
+	ctx := context.Background()
+	_, err := client.Alias().Add(index, "production").Do(ctx)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Index %s promoted.", index)
 	return nil
 }

--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -52,13 +52,12 @@ func createRecordIndex(client *elastic.Client, index string) error {
 	if err != nil {
 		panic(err)
 	}
-	log.Println("Index created")
+	log.Println("Index created:", index)
 	return nil
 }
 
 func previous(client *elastic.Client, prefix string) ([]string, error) {
 	// retrieve all indexes linked to production alias and filter by supplied prefix. These are the "old" indexes.
-	log.Printf("previous!")
 	aliases, err := aliases(client)
 	if err != nil {
 		return nil, err
@@ -73,10 +72,10 @@ func previous(client *elastic.Client, prefix string) ([]string, error) {
 	}
 
 	if len(aliases) == 0 {
-		fmt.Printf("No aliases found. Nothing to demote.")
+		log.Printf("No aliases found. Nothing to demote.")
 	}
 
-	log.Println(indexes)
+	log.Println("Previous indexes:", indexes)
 
 	return indexes, nil
 }
@@ -97,7 +96,7 @@ func delete(client *elastic.Client, index string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Index deleted")
+	log.Printf("Index deleted")
 	return nil
 }
 
@@ -107,7 +106,7 @@ func demote(client *elastic.Client, index string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Index %s demoted.", index)
+	log.Println("Index demoted:", index)
 	return nil
 }
 
@@ -127,7 +126,7 @@ func indexes(client *elastic.Client) error {
 			i.Index, i.DocsCount, i.Health, i.Status, i.UUID, i.StoreSize)
 	}
 	if len(indexes) == 0 {
-		fmt.Printf("No indexes found.")
+		log.Printf("No indexes found.")
 	}
 	return nil
 }
@@ -156,6 +155,6 @@ func promote(client *elastic.Client, index string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Index %s promoted.", index)
+	log.Println("Index promoted:", index)
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func main() {
 					// this is an aleph update. Determine the index that is currently
 					// associated with `production` with the aleph prefix and set that
 					// as the index name.
-					println("Update file detected.")
+					log.Printf("Update file detected.")
 					client, err := esClient(url, index, v4)
 					if err != nil {
 						return err


### PR DESCRIPTION
#### What does this PR do?

- previously hardcoded "aleph" value is now the default of a new flag "prefix"
- auto mode will create a new index, demote any old indexes with the supplied prefix, and promote the new index. Auto mode will not demote any indexes that have different prefixes.
- a known pattern for aleph daily update files will override auto mode (so the s3 trigger can remain the same for both modes [alternatively the lambda would have to deal with this]) and instead select the current index for the prefix supplied. If there is not one current index it stops processing and reports an error condition.
- shared es logic moved to existing `elasticsearch.go` file

#### How can a reviewer manually see the effects of these changes?

- Ingest a few files
- Promote one to production
- Ingest a new file in `auto` mode. You should now see the new ingest as production and the previous production has been demoted

- with one index promoted, ingest an aleph update file. You should not get a new index, but the records will update (or be created) in the existing promoted index

- with two indexes promoted and _both_ having the `aleph` prefix, running an update should error and no changes should have been made to any indexes

- with two different prefixes promoted, running an update should proceed and update the properly prefixed promoted index


#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-210

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO
