### PR TITLE
Add Makefile for building container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
-FROM golang:1.11
+FROM golang:1.11-alpine
 
+RUN apk add --no-cache curl git
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 WORKDIR /go/src/mario
-COPY . .
-RUN dep ensure
-RUN go install
+COPY Gopkg.* ./
+RUN dep ensure -vendor-only
+COPY *.go ./
+RUN go build
 
-ENTRYPOINT ["mario"]
+FROM alpine
+COPY --from=0 /go/src/mario/mario .
+COPY config config/
+ENTRYPOINT ["./mario"]
 CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+.PHONY: help install test tests update dist publish
+SHELL=/bin/bash
+ECR_REGISTRY=672626379771.dkr.ecr.us-east-1.amazonaws.com
+
+help: ## Print this message
+	@awk 'BEGIN { FS = ":.*##"; print "Usage:  make <target>\n\nTargets:" } \
+		/^[-_[:alpha:]]+:.?*##/ { printf "  %-15s%s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+install: ## Install mario binary
+	dep ensure
+	go install
+
+test: ## Run tests
+	go test
+
+tests: test
+
+update: ## Update dependencies
+	dep ensure -update
+
+dist: ## Build docker image
+	docker build -t $(ECR_REGISTRY)/mario-stage:latest \
+		-t $(ECR_REGISTRY)/mario-stage:`git describe --always` \
+		-t mario:latest .
+	@tput setaf 2
+	@tput bold
+	@echo "Finished building docker image. Try running:"
+	@echo "  $$ docker run --rm mario:latest"
+	@tput sgr0
+
+publish: dist ## Build, tag and push
+	$$(aws ecr get-login --no-include-email --region us-east-1)
+	docker push $(ECR_REGISTRY)/mario-stage:latest
+	docker push $(ECR_REGISTRY)/mario-stage:`git describe --always`


### PR DESCRIPTION
This adds a Makefile to simplify the process of building the container
and pushing it to the ECR repo. I've also modified the Dockerfile to
shrink the size of the resulting image.

#### How can a reviewer manually see the effects of these changes?

You'll need a docker version >=17.05 in order to build the container.

```
$ make dist
$ docker run --rm mario
```

You should see the mario help page. Doing anything more than this with the container would require shenanigans.

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
