### PR TITLE
Add deploy stage to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,10 @@ install:
   - dep ensure
 
 script: go test -v ./...
+
+before_deploy: make dist
+
+deploy:
+  skip_cleanup: true
+  provider: script
+  script: make publish


### PR DESCRIPTION
When merging a PR onto master travis will now build the docker image and
push it to the AWS ECR staging repo.

#### How can a reviewer manually see the effects of these changes?

This stage will only run when merging to master, so there's no way to review.

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO
