### PR TITLE
Install AWS CLI to user only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 script: go test -v ./...
 
 before_deploy:
-  - pip install awscli
+  - pip install --user awscli
   - make dist
 
 deploy:


### PR DESCRIPTION
In non-Python builds pip defaults to system-wide installation.
