### PR TITLE
Add certs to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.11-alpine
 
-RUN apk add --no-cache curl git
+RUN apk add --no-cache curl git ca-certificates
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 WORKDIR /go/src/mario
 COPY Gopkg.* ./
@@ -9,6 +9,7 @@ COPY *.go ./
 RUN go build
 
 FROM alpine
+COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=0 /go/src/mario/mario .
 COPY config config/
 ENTRYPOINT ["./mario"]


### PR DESCRIPTION
Because Go for some reason won't just blindly accept whatever dodgy
certificate it encounters.

#### How can a reviewer manually see the effects of these changes?

You can't really. You have to run the Fargate task to see the original error message.

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO
