### PR TITLE
Replace 'country_of_publication' with 'place_of_publication' in data model

### DIFF
--- a/config/es_record_mappings.json
+++ b/config/es_record_mappings.json
@@ -57,16 +57,6 @@
             }
           }
         },
-        "country_of_publication": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "normalizer": "lowercase",
-              "ignore_above": 256
-            }
-          }
-        },
         "creators": {
           "type": "text",
           "fields": {
@@ -165,6 +155,16 @@
         },
         "physical_description": {
           "type": "text"
+        },
+        "place_of_publication": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "normalizer": "lowercase",
+              "ignore_above": 256
+            }
+          }
         },
         "publication_date": {
           "type": "text",

--- a/config/marc_rules.json
+++ b/config/marc_rules.json
@@ -76,7 +76,7 @@
     ]
   },
   {
-    "label": "country_of_publication",
+    "label": "place_of_publication",
     "array": false,
     "fields": [
       {

--- a/marc.go
+++ b/marc.go
@@ -132,7 +132,7 @@ func marcToRecord(fmlRecord fml.Record, rules []*Rule, languageCodes map[string]
 	r.Issn = applyRule(fmlRecord, rules, "issns")
 	r.Doi = applyRule(fmlRecord, rules, "dois")
 
-	country := applyRule(fmlRecord, rules, "country_of_publication")
+	country := applyRule(fmlRecord, rules, "place_of_publication")
 	if country != nil {
 		country[0] = strings.Trim(country[0], " |")
 		r.Country = TranslateCodes(country, countryCodes)[0]

--- a/record.go
+++ b/record.go
@@ -16,7 +16,7 @@ type Record struct {
 	Doi                  []string       `json:"dois,omitempty"`
 	OclcNumber           []string       `json:"oclcs,omitempty"`
 	Lccn                 string         `json:"lccn,omitempty"`
-	Country              string         `json:"country_of_publication,omitempty"`
+	Country              string         `json:"place_of_publication,omitempty"`
 	Language             []string       `json:"languages,omitempty"`
 	PublicationDate      string         `json:"publication_date,omitempty"`
 	ContentType          string         `json:"content_type,omitempty"`


### PR DESCRIPTION
#### What does this PR do?

Replaces 'country_of_publication' with 'place_of_publication' in the data model, because many MARC records use state or other location types that are not countries.

#### How can a reviewer manually see the effects of these changes?

Reindex and view record

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-221

#### Requires Full Reindexing of all Sources?
YES

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
