### PR TITLE
Add promote target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-.PHONY: help install test tests update dist publish
+.PHONY: help install test tests update dist publish promote
 SHELL=/bin/bash
 ECR_REGISTRY=672626379771.dkr.ecr.us-east-1.amazonaws.com
+DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)
 
 help: ## Print this message
 	@awk 'BEGIN { FS = ":.*##"; print "Usage:  make <target>\n\nTargets:" } \
@@ -32,3 +33,11 @@ publish: dist ## Build, tag and push
 	$$(aws ecr get-login --no-include-email --region us-east-1)
 	docker push $(ECR_REGISTRY)/mario-stage:latest
 	docker push $(ECR_REGISTRY)/mario-stage:`git describe --always`
+
+promote: ## Promote the current staging build to production
+	$$(aws ecr get-login --no-include-email --region us-east-1)
+	docker pull $(ECR_REGISTRY)/mario-stage:latest
+	docker tag $(ECR_REGISTRY)/mario-stage:latest $(ECR_REGISTRY)/mario-prod:latest
+	docker tag $(ECR_REGISTRY)/mario-stage:latest $(ECR_REGISTRY)/mario-prod:$(DATETIME)
+	docker push $(ECR_REGISTRY)/mario-prod:latest
+	docker push $(ECR_REGISTRY)/mario-prod:$(DATETIME)


### PR DESCRIPTION
The promote target should be run manually whenever you are ready to
deploy the latest staging build to production. It will copy the image
tagged `latest` from the stage registry to the prod registry.

#### How can a reviewer manually see the effects of these changes?

You can't, unless you want to promote to production as part of the review.

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO
