### PR TITLE
Dip 192 remove duplicate values

### DIFF
--- a/marc.go
+++ b/marc.go
@@ -206,10 +206,24 @@ func extractData(rule *Rule, fmlRecord fml.Record) []string {
 	for _, r := range rule.Fields {
 		f := filter(fmlRecord, r)
 		for _, y := range f {
-			field = append(field, y)
+			if !stringInSlice(y, field) {
+				field = append(field, y)
+			}
 		}
 	}
 	return field
+}
+
+// stringInSlice determines whether a supplied string is an item in a supplied slice.
+// Returns true if the string is in the slice, and returns false otherwise.
+// Taken from https://stackoverflow.com/a/15323988
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
 }
 
 func filter(fmlRecord fml.Record, field *Field) []string {

--- a/marc_test.go
+++ b/marc_test.go
@@ -242,3 +242,11 @@ func TestMarcProcess(t *testing.T) {
 		t.Error("Expected match, got", i)
 	}
 }
+
+func TestStringInSlice(t *testing.T) {
+	l := []string{"hello", "goodbye"}
+	r := stringInSlice("hello", l)
+	if r != true {
+		t.Error("Expected true, got", r)
+	}
+}

--- a/record.go
+++ b/record.go
@@ -61,10 +61,10 @@ type Link struct {
 // Holding is a port of a Record
 type Holding struct {
 	Location   string `json:"location"`
-	Collection string `json:"collection"`
+	Collection string `json:"collection,omitempty"`
 	CallNumber string `json:"call_number"`
-	Summary    string `json:"summary"`
-	Notes      string `json:"notes"`
+	Summary    string `json:"summary,omitempty"`
+	Notes      string `json:"notes,omitempty"`
 }
 
 // Rule defines where the rules are in JSON


### PR DESCRIPTION
#### What does this PR do?

Removes duplicate values from fields and removes empty values from holdings field.

#### How can a reviewer manually see the effects of these changes?

Reindex and look at record. Subjects field previously had a lot of duplicates and doesn't anymore, and there should be no blank values in the holdings field.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-192

#### Requires Full Reindexing of all Sources?
YES

#### Includes new or updated dependencies?
YES | NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
