### PR TITLE
Remove format field from record and add format to holdings

### DIFF
--- a/config/es_record_mappings.json
+++ b/config/es_record_mappings.json
@@ -102,6 +102,9 @@
             },
             "summary": {
               "type": "text"
+            },
+            "format": {
+              "type": "text"
             }
           }
         },

--- a/config/es_record_mappings.json
+++ b/config/es_record_mappings.json
@@ -73,16 +73,6 @@
         "edition": {
           "type": "text"
         },
-        "format": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "normalizer": "lowercase",
-              "ignore_above": 256
-            }
-          }
-        },
         "holdings": {
           "properties": {
             "call_number": {

--- a/config/es_record_mappings.json
+++ b/config/es_record_mappings.json
@@ -73,6 +73,16 @@
         "edition": {
           "type": "text"
         },
+        "format": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "normalizer": "lowercase",
+              "ignore_above": 256
+            }
+          }
+        },
         "holdings": {
           "properties": {
             "call_number": {

--- a/config/marc_rules.json
+++ b/config/marc_rules.json
@@ -311,28 +311,6 @@
     ]
   },
   {
-    "label": "format",
-    "array": true,
-    "fields": [
-      {
-        "tag": "852",
-        "subfields": "b",
-        "notes": "Lookup table required to translate values from those fields"
-      }
-    ]
-  },
-  {
-    "label": "format",
-    "array": true,
-    "fields": [
-      {
-        "tag": "852",
-        "subfields": "k",
-        "notes": "Lookup table required to translate values from those fields"
-      }
-    ]
-  },
-  {
     "label": "content_type",
     "array": true,
     "fields": [
@@ -499,7 +477,7 @@
       },
       {
         "tag": "852",
-        "subfields": "bcha",
+        "subfields": "bchak",
         "notes": "We fall back on 852 if 866 does not exist. We can't use our normal rule parsing for this as we need to split the subfields into a structure in a way that doesn't fit our normal expectations."
       }
     ]

--- a/marc.go
+++ b/marc.go
@@ -187,6 +187,12 @@ func marcToRecord(fmlRecord fml.Record, rules []*Rule, languageCodes map[string]
 		r.Holdings = getHoldings(fmlRecord, "852", []string{"b", "c", "h", "a", "z", "k"})
 	}
 
+	for _, h := range r.Holdings {
+		if !stringInSlice(h.Format, r.Format) {
+			r.Format = append(r.Format, h.Format)
+		}
+	}
+
 	return r, err
 }
 

--- a/marc.go
+++ b/marc.go
@@ -589,10 +589,10 @@ func lookupLocation(loc string) string {
 	return t
 }
 
-func lookupFormat(loc string, format_code string) string {
+func lookupFormat(loc string, formatCode string) string {
 	var t string
 	if loc != "Internet Resource" {
-		switch format_code {
+		switch formatCode {
 		case "BOOKS", "REGULAR":
 			t = "Print volume"
 		case "ATLAS":

--- a/marc.go
+++ b/marc.go
@@ -188,8 +188,9 @@ func marcToRecord(fmlRecord fml.Record, rules []*Rule, languageCodes map[string]
 	}
 
 	for _, h := range r.Holdings {
-		if !stringInSlice(h.Format, r.Format) {
-			r.Format = append(r.Format, h.Format)
+		f := h.Format
+		if f != "" && !stringInSlice(f, r.Format) {
+			r.Format = append(r.Format, f)
 		}
 	}
 

--- a/marc.go
+++ b/marc.go
@@ -175,9 +175,6 @@ func marcToRecord(fmlRecord fml.Record, rules []*Rule, languageCodes map[string]
 
 	r.Summary = applyRule(fmlRecord, rules, "summary")
 
-	// TODO: use lookup tables to translate returned codes to values
-	r.Format = applyRule(fmlRecord, rules, "format")
-
 	r.ContentType = contentType(fmlRecord.Leader.Type)
 
 	lf := applyRule(fmlRecord, rules, "literary_form")
@@ -187,7 +184,7 @@ func marcToRecord(fmlRecord fml.Record, rules []*Rule, languageCodes map[string]
 	r.Holdings = getHoldings(fmlRecord, "866", []string{"b", "c", "h", "a", "z"})
 
 	if len(r.Holdings) == 0 {
-		r.Holdings = getHoldings(fmlRecord, "852", []string{"b", "c", "h", "a", "z"})
+		r.Holdings = getHoldings(fmlRecord, "852", []string{"b", "c", "h", "a", "z", "k"})
 	}
 
 	return r, err
@@ -423,6 +420,11 @@ func getHoldings(fmlRecord fml.Record, tag string, subfieldCodes []string) []Hol
 			CallNumber: subfieldValue(f.SubFields, subfieldCodes[2]),
 			Summary:    subfieldValue(f.SubFields, subfieldCodes[3]),
 			Notes:      subfieldValue(f.SubFields, subfieldCodes[4])}
+		if tag == "866" {
+			holding.Format = "Print volume"
+		} else {
+			holding.Format = lookupFormat(holding.Location, subfieldValue(f.SubFields, subfieldCodes[5]))
+		}
 		holdings = append(holdings, holding)
 	}
 	return holdings
@@ -576,6 +578,49 @@ func lookupLocation(loc string) string {
 		t = "Office delivery"
 	default:
 		t = loc
+	}
+	return t
+}
+
+func lookupFormat(loc string, format_code string) string {
+	var t string
+	if loc != "Internet Resource" {
+		switch format_code {
+		case "BOOKS", "REGULAR":
+			t = "Print volume"
+		case "ATLAS":
+			t = "Atlas"
+		case "AUDIO", "AUDTAPE":
+			t = "Audio tape"
+		case "CD":
+			t = "Compact disc"
+		case "CDROM":
+			t = "CD-ROM"
+		case "DSKETTE":
+			t = "Diskette"
+		case "DVD":
+			t = "DVD-ROM"
+		case "FICHE":
+			t = "Microfiche"
+		case "FOLIO", "OVRSIZE":
+			t = "Oversized print volume"
+		case "MAP":
+			t = "Map sheet"
+		case "MFILM":
+			t = "Microfilm"
+		case "RECORD":
+			t = "Audio record"
+		case "SCORE":
+			t = "Musical score"
+		case "SMALL":
+			t = "Undersized print volume"
+		case "VDISC":
+			t = "Videodisc"
+		case "VHS":
+			t = "VHS"
+		default:
+			t = "Print volume"
+		}
 	}
 	return t
 }

--- a/marc_test.go
+++ b/marc_test.go
@@ -108,6 +108,10 @@ func TestMarcHoldings(t *testing.T) {
 		t.Error("Expected match, got", h.Collection)
 	}
 
+	if h.Format != "Print volume" {
+		t.Error("Expected match, got", h.Format)
+	}
+
 	// This record has no 866 or 852 fields
 	_ = records.Next()
 	record, _ = records.Value()
@@ -130,6 +134,9 @@ func TestMarcHoldings(t *testing.T) {
 	}
 	if h.Summary != "1995 and updates" {
 		t.Error("Expected match, got", h.Summary)
+	}
+	if h.Format != "Print volume" {
+		t.Error("Expected match, got", h.Format)
 	}
 }
 

--- a/record.go
+++ b/record.go
@@ -29,7 +29,6 @@ type Record struct {
 	Notes                []string       `json:"notes,omitempty"`
 	Contents             []string       `json:"contents,omitempty"`
 	Summary              []string       `json:"summary,omitempty"`
-	Format               []string       `json:"format,omitempty"`
 	LiteraryForm         string         `json:"literary_form,omitempty"`
 	RelatedPlace         []string       `json:"related_place,omitempty"`
 	InBibliography       []string       `json:"in_bibliography,omitempty"`
@@ -65,6 +64,7 @@ type Holding struct {
 	CallNumber string `json:"call_number"`
 	Summary    string `json:"summary,omitempty"`
 	Notes      string `json:"notes,omitempty"`
+	Format     string `json:"format,omitempty"`
 }
 
 // Rule defines where the rules are in JSON

--- a/record.go
+++ b/record.go
@@ -29,6 +29,7 @@ type Record struct {
 	Notes                []string       `json:"notes,omitempty"`
 	Contents             []string       `json:"contents,omitempty"`
 	Summary              []string       `json:"summary,omitempty"`
+	Format               []string       `json:"format,omitempty"`
 	LiteraryForm         string         `json:"literary_form,omitempty"`
 	RelatedPlace         []string       `json:"related_place,omitempty"`
 	InBibliography       []string       `json:"in_bibliography,omitempty"`


### PR DESCRIPTION
#### What does this PR do?

Removes format field from record and instead includes format in holdings, since we often have multiple holdings of a single item in different formats (e.g., a print volume and an electronic resource). This decision was made with input from metadata folks who agreed that it makes the most sense. Note that "Internet resource" holdings do not list a format, since the location is already clearly defined as "Internet resource" and format would be identical to that.

#### How can a reviewer manually see the effects of these changes?

Re-index and view records. Format is now part of the holdings field.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-149

#### Requires Full Reindexing of all Sources?
YES

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
