### PR TITLE
Leader status check, ES error checking, Dates are text now

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,14 +3,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:de53ea25bf07faeb942289aab1f06a25e9afadacd57c722ec145ca0cc7f73cc7"
+  digest = "1:49706875bd62e17a1a2eef9bee3d118f1627bcb877779442900b3061c6a3e99c"
   name = "github.com/MITLibraries/fml"
   packages = ["."]
   pruneopts = "UT"
-  revision = "a79082be5fac8291d39578f5ee5641ea0e660e8e"
+  revision = "cd8e755ed2153200e827c8c91665301d9244f302"
 
 [[projects]]
-  digest = "1:d41cff10314da0d12d0e09d474eb20a9e327b0f30cd359886ccae53ae509047f"
+  digest = "1:13e30c1638ea16b0fa641cd8d6db690778ca3778ff81bf28b02a826ed5a0b74b"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -49,8 +49,8 @@
     "service/sts",
   ]
   pruneopts = "UT"
-  revision = "d2d8f8c33f49af99cdd889f6897ffd525c520407"
-  version = "v1.16.19"
+  revision = "25f89dc67cc7eddac939028c7128499dcfcab46b"
+  version = "v1.16.33"
 
 [[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
@@ -81,7 +81,7 @@
   revision = "60711f1a8329503b04e1c88535f419d0bb440bff"
 
 [[projects]]
-  digest = "1:a4685fac9d8029adf81c4c05331d4be3a6b8f5b4680831ae38bf26dc3ecab543"
+  digest = "1:29d64f8d7e127ac9360b0ebbdd0707772e06879ed4b24117ecd3a1c0dc3e18a1"
   name = "github.com/olivere/elastic"
   packages = [
     ".",
@@ -90,8 +90,8 @@
     "uritemplates",
   ]
   pruneopts = "UT"
-  revision = "f5738570b28a4b5fab39442e3a5b5ffc599a562c"
-  version = "v6.2.15"
+  revision = "407a1d940dcc89e279c579eb393d0bdde8fd9ac4"
+  version = "v6.2.16"
 
 [[projects]]
   digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,13 @@
 
 
 [[projects]]
-  branch = "master"
-  digest = "1:49706875bd62e17a1a2eef9bee3d118f1627bcb877779442900b3061c6a3e99c"
+  branch = "bad-dir-fix"
+  digest = "1:9ac58e42f094f3145dba853894f272263a1e6d17c52a4fb16e60596b7cf17b75"
   name = "github.com/MITLibraries/fml"
   packages = ["."]
   pruneopts = "UT"
-  revision = "cd8e755ed2153200e827c8c91665301d9244f302"
+  revision = "039bc133960e84a958596cd42de9995725e16f37"
+  source = "github.com/MITLibraries/fml"
 
 [[projects]]
   digest = "1:13e30c1638ea16b0fa641cd8d6db690778ca3778ff81bf28b02a826ed5a0b74b"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,16 +2,15 @@
 
 
 [[projects]]
-  branch = "bad-dir-fix"
+  branch = "master"
   digest = "1:9ac58e42f094f3145dba853894f272263a1e6d17c52a4fb16e60596b7cf17b75"
   name = "github.com/MITLibraries/fml"
   packages = ["."]
   pruneopts = "UT"
-  revision = "039bc133960e84a958596cd42de9995725e16f37"
-  source = "github.com/MITLibraries/fml"
+  revision = "1b7d63d69dfb2076f4cdca5316d6a0a212d69186"
 
 [[projects]]
-  digest = "1:13e30c1638ea16b0fa641cd8d6db690778ca3778ff81bf28b02a826ed5a0b74b"
+  digest = "1:50b0d6f65430d40988dc5b5fcf43e3b0c3af5bb554aba6d7ff68353424dcfdab"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -50,8 +49,8 @@
     "service/sts",
   ]
   pruneopts = "UT"
-  revision = "25f89dc67cc7eddac939028c7128499dcfcab46b"
-  version = "v1.16.33"
+  revision = "24d2586ee6c7aa6a6efec818c2b8709db125ee4c"
+  version = "v1.16.34"
 
 [[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -10,10 +10,10 @@
 #   name = "github.com/user/project"
 #   version = "1.0.0"
 #
-# [[constraint]]
-#   name = "github.com/user/project2"
-#   branch = "dev"
-#   source = "github.com/myfork/project2"
+ [[constraint]]
+   name = "github.com/MITLibraries/fml"
+   branch = "bad-dir-fix"
+   source = "github.com/MITLibraries/fml"
 #
 # [[override]]
 #   name = "github.com/x/y"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -10,10 +10,10 @@
 #   name = "github.com/user/project"
 #   version = "1.0.0"
 #
- [[constraint]]
-   name = "github.com/MITLibraries/fml"
-   branch = "bad-dir-fix"
-   source = "github.com/MITLibraries/fml"
+# [[constraint]]
+#   name = "github.com/user/project2"
+#   branch = "dev"
+#   source = "github.com/myfork/project2"
 #
 # [[override]]
 #   name = "github.com/x/y"

--- a/config/es_record_mappings.json
+++ b/config/es_record_mappings.json
@@ -173,7 +173,7 @@
           "type": "text",
           "fields": {
             "date": {
-              "type": "date"
+              "type": "text"
             }
           }
         },

--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -158,3 +158,7 @@ func promote(client *elastic.Client, index string) error {
 	log.Println("Index promoted:", index)
 	return nil
 }
+
+func after(exId int64, requests []elastic.BulkableRequest, resp *elastic.BulkResponse, err error) {
+	fmt.Printf("Request ID: %d -- Errors: %t\n", exId, resp.Errors)
+}

--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -159,9 +159,9 @@ func promote(client *elastic.Client, index string) error {
 	return nil
 }
 
-func after(exId int64, requests []elastic.BulkableRequest, resp *elastic.BulkResponse, err error) {
+func after(exID int64, requests []elastic.BulkableRequest, resp *elastic.BulkResponse, err error) {
 	if resp.Errors == true {
-		fmt.Printf("Request ID: %d -- Errors: %t\n", exId, resp.Errors)
+		fmt.Printf("Request ID: %d -- Errors: %t\n", exID, resp.Errors)
 		errs := resp.Failed()
 		for _, e := range errs {
 			fmt.Println(e.Error)

--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -160,5 +160,11 @@ func promote(client *elastic.Client, index string) error {
 }
 
 func after(exId int64, requests []elastic.BulkableRequest, resp *elastic.BulkResponse, err error) {
-	fmt.Printf("Request ID: %d -- Errors: %t\n", exId, resp.Errors)
+	if resp.Errors == true {
+		fmt.Printf("Request ID: %d -- Errors: %t\n", exId, resp.Errors)
+		errs := resp.Failed()
+		for _, e := range errs {
+			fmt.Println(e.Error)
+		}
+	}
 }

--- a/main.go
+++ b/main.go
@@ -152,7 +152,7 @@ func main() {
 						createRecordIndex(client, index)
 					}
 
-					es, err := client.BulkProcessor().Name("IngestWorker-1").Do(context.Background())
+					es, err := client.BulkProcessor().After(after).Name("IngestWorker-1").Workers(2).Do(context.Background())
 					if err != nil {
 						return err
 					}

--- a/marc.go
+++ b/marc.go
@@ -73,8 +73,7 @@ func (m *MarcGenerator) Generate() <-chan Record {
 
 func (m *marcparser) parse(out chan Record) {
 	mr := fml.NewMarcIterator(m.file)
-	var dumb_counter int
-	var error_counter int
+	var errorCount int
 
 	for mr.Next() {
 		record, err := mr.Value()
@@ -85,22 +84,20 @@ func (m *marcparser) parse(out chan Record) {
 			// os.Stderr.WriteString("--- Begin Problem MARC Record ---\n")
 			// os.Stderr.Write(record.Data)
 			// os.Stderr.WriteString("\n--- End Problem MARC Record ---\n")
-			error_counter++
+			errorCount++
 			continue
 		}
 
 		r, err := marcToRecord(record, m.rules, m.languageCodes, m.countryCodes)
 		if err != nil {
-			error_counter++
+			errorCount++
 			log.Println(err)
 		} else {
-			dumb_counter++
 			out <- r
 		}
 	}
 
-	log.Printf("Processed records: %s", strconv.Itoa(dumb_counter))
-	log.Printf("Error records: %s", strconv.Itoa(error_counter))
+	log.Printf("Error records: %s", strconv.Itoa(errorCount))
 	close(out)
 }
 
@@ -119,7 +116,7 @@ func marcToRecord(fmlRecord fml.Record, rules []*Rule, languageCodes map[string]
 	r.Identifier = fmlRecord.ControlNum()
 
 	if fmlRecord.Leader.Status == 'd' {
-		err = fmt.Errorf("Record %s has been deleted or suppressed but we don't handle that yet.", r.Identifier)
+		err = fmt.Errorf("Record %s has been deleted or suppressed but we don't handle that yet", r.Identifier)
 		return r, err
 	}
 


### PR DESCRIPTION
#### What does this PR do?

- updates fml and other dependencies (good luck!)
- checks for legal statuses for Leader.Status and skips records that are either deletes / suppressions or not valid (we'll come back to the deletes / suppressions later)
- adds count for errors
- adds additional worker for bulkinserts
- adds callback to bulkinserts, checks for errors, and logs them if they exist
- changes the date field in Elasticsearch to `text` instead of `date`. This is far from ideal but is a bandaid to get all of the records indexed. A new ticket has been opened to address this more usefully in the the future: https://mitlibraries.atlassian.net/browse/DIP-248

#### Helpful background context

- Dates are awful + MARC is awful = fml

#### How can a reviewer manually see the effects of these changes?

Pulling this branch and running a full index into Elasticsearch should now:
- actually complete now
- use text fields for dates
- index records that have non-date dates

#### Requires Full Reindexing of all Sources?
YES

#### Includes new or updated dependencies?
YES
