### PR TITLE
Remove old system numbers and prefix from OCLC numbers

### DIFF
--- a/marc.go
+++ b/marc.go
@@ -127,7 +127,9 @@ func marcToRecord(fmlRecord fml.Record, rules []*Rule, languageCodes map[string]
 
 	r.Source = "MIT Aleph"
 	r.SourceLink = "https://library.mit.edu/item/" + r.Identifier
-	r.OclcNumber = applyRule(fmlRecord, rules, "oclc_number")
+
+	oclcs := applyRule(fmlRecord, rules, "oclc_number")
+	r.OclcNumber = cleanOclcs(oclcs)
 
 	lccn := applyRule(fmlRecord, rules, "lccn")
 	if lccn != nil {
@@ -241,6 +243,17 @@ func extractData(rule *Rule, fmlRecord fml.Record) []string {
 		}
 	}
 	return field
+}
+
+func cleanOclcs(oclcs []string) []string {
+	var cleaned []string
+	for _, n := range oclcs {
+		if strings.Contains(n, "OCoLC") {
+			ns := strings.Replace(n, "(OCoLC)", "", 1)
+			cleaned = append(cleaned, ns)
+		}
+	}
+	return cleaned
 }
 
 // stringInSlice determines whether a supplied string is an item in a supplied slice.


### PR DESCRIPTION
#### What does this PR do?

Only keeps OCLC numbers for our OclcNumbers field and removes an unnecessary prefix from same.

#### How can a reviewer manually see the effects of these changes?

`mario ingest --debug --consumer json fixtures/mit_test_records.mrc` on master and this branch and note the master branch has a bunch of old system numbers and the OCLC number has a prefix that this branch removes.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-256

#### Requires Full Reindexing of all Sources?
YES, ideally.

#### Includes new or updated dependencies?
NO