### PR TITLE
Combine authors and contributors as contributors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ debug
 
 # System files
 .DS_Store
+tmp/

--- a/config/es_record_mappings.json
+++ b/config/es_record_mappings.json
@@ -34,6 +34,7 @@
           "type": "text"
         },
         "contributors": {
+          "type": "nested",
           "properties": {
             "kind": {
               "type": "text",

--- a/config/es_record_mappings.json
+++ b/config/es_record_mappings.json
@@ -57,16 +57,6 @@
             }
           }
         },
-        "creators": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "normalizer": "lowercase",
-              "ignore_above": 256
-            }
-          }
-        },
         "dois": {
           "type": "text"
         },

--- a/config/marc_rules.json
+++ b/config/marc_rules.json
@@ -333,41 +333,38 @@
     ]
   },
   {
-    "label": "creators",
-    "array": true,
-    "fields": [
-      {
-        "tag": "100",
-        "subfields": "abcdeq"
-      },
-      {
-        "tag": "110",
-        "subfields": "abcde"
-      },
-      {
-        "tag": "111",
-        "subfields": "abcdefgjq"
-      }
-    ]
-  },
-  {
     "label": "contributors",
     "array": true,
     "fields": [
       {
+        "tag": "100",
+        "subfields": "abceqd",
+        "kind": "author"
+      },
+      {
+        "tag": "110",
+        "subfields": "abcde",
+        "kind": "author"
+      },
+      {
+        "tag": "111",
+        "subfields": "abcdefgjq",
+        "kind": "author"
+      },
+      {
         "tag": "700",
-        "subfields": "abcdeq",
-        "kind": "contributor added entry"
+        "subfields": "abceqd",
+        "kind": "contributor"
       },
       {
         "tag": "710",
         "subfields": "abcde",
-        "kind": "creator CB added entry"
+        "kind": "contributor"
       },
       {
         "tag": "711",
         "subfields": "acdefgjq",
-        "kind": "contributor conf added entry"
+        "kind": "contributor"
       }
     ]
   },

--- a/marc.go
+++ b/marc.go
@@ -145,7 +145,6 @@ func marcToRecord(fmlRecord fml.Record, rules []*Rule, languageCodes map[string]
 	}
 
 	r.AlternateTitles = applyRule(fmlRecord, rules, "alternate_titles")
-	r.Creator = applyRule(fmlRecord, rules, "creators")
 	r.Contributor = getContributors(fmlRecord, rules, "contributors")
 
 	r.RelatedPlace = applyRule(fmlRecord, rules, "related_place")
@@ -287,20 +286,23 @@ func filter(fmlRecord fml.Record, field *Field) []string {
 // returns slice of contributors of marc fields taking into account the rules for which fields and subfields we care about as defined in marc_rules.json
 func getContributors(fmlRecord fml.Record, rules []*Rule, field string) []*Contributor {
 	recordFieldRule := getRules(rules, field)
-	var c []*Contributor
+	var contribs []*Contributor
 
 	for _, r := range recordFieldRule.Fields {
-		y := new(Contributor)
-		y.Kind = r.Kind
 
-		y.Value = filter(fmlRecord, r)
+		for _, contrib := range filter(fmlRecord, r) {
+			y := new(Contributor)
+			y.Kind = r.Kind
+			y.Value = contrib
 
-		if y.Value != nil {
-			c = append(c, y)
+			if y.Value != "" {
+				contribs = append(contribs, y)
+			}
 		}
+
 	}
 
-	return c
+	return contribs
 }
 
 // returns slice of related items of marc fields taking into account the rules for which fields and subfields we care about as defined in marc_rules.json

--- a/marc_test.go
+++ b/marc_test.go
@@ -41,8 +41,12 @@ func TestMarcToRecord(t *testing.T) {
 
 	item, _ := marcToRecord(record, rules, languageCodes, countryCodes)
 
-	if item.Creator[0] != "Sandburg, Carl, 1878-1967." {
-		t.Error("Expected match, got", item.Creator)
+	if item.Contributor[0].Value != "Sandburg, Carl, 1878-1967." {
+		t.Error("Expected match, got", item.Contributor[0].Value)
+	}
+
+	if item.Contributor[0].Kind != "author" {
+		t.Error("Expected match, got", item.Contributor[0].Kind)
 	}
 
 	if item.Identifier != "92005291" {
@@ -51,10 +55,6 @@ func TestMarcToRecord(t *testing.T) {
 
 	if item.Title != "Arithmetic /" {
 		t.Error("Expected match, got", item.Title)
-	}
-
-	if item.Contributor[0].Value[0] != "Rand, Ted, ill." {
-		t.Error("Expected match, got", item.Contributor[0].Value[0])
 	}
 
 	if item.Subject[0] != "Arithmetic Juvenile poetry." {

--- a/record.go
+++ b/record.go
@@ -8,7 +8,6 @@ type Record struct {
 	SourceLink           string         `json:"source_link"`
 	Title                string         `json:"title"`
 	AlternateTitles      []string       `json:"alternate_titles,omitempty"`
-	Creator              []string       `json:"creators,omitempty"`
 	Contributor          []*Contributor `json:"contributors,omitempty"`
 	Subject              []string       `json:"subjects,omitempty"`
 	Isbn                 []string       `json:"isbns,omitempty"`
@@ -40,8 +39,8 @@ type Record struct {
 
 // Contributor is a port of a Record
 type Contributor struct {
-	Kind  string   `json:"kind"`
-	Value []string `json:"value"`
+	Kind  string `json:"kind"`
+	Value string `json:"value"`
 }
 
 // RelatedItem is a port of a Record


### PR DESCRIPTION
#### What does this PR do?

Combines authors into the contributor field. Future work will provide additional "kinds" of contributors but for now a generic "author" for 1xx and "contributor" for 7xx fields is our path forward. Future work under DIP-259 has been proposed to handle the more detailed "kinds".

#### How can a reviewer manually see the effects of these changes?

Ingest some records and check the contributors to see both 1xx and 7xx fields included.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-257
- https://mitlibraries.atlassian.net/browse/DIP-253

#### Requires Full Reindexing of all Sources?
YES

Additionally, TIMDEX needs to handle these changes prior to a full reindex.

#### Includes new or updated dependencies?
NO
