### PR TITLE
title exact_value field strips trailing punctuation

### DIFF
--- a/config/es_record_mappings.json
+++ b/config/es_record_mappings.json
@@ -1,6 +1,25 @@
 {
   "settings": {
     "analysis": {
+      "analyzer": {
+        "keyword_no_trailing_punctuation": {
+          "tokenizer": "keyword",
+          "char_filter": [
+            "no_trailing_punctuation"
+          ],
+          "filter": [
+            "lowercase",
+            "trim"
+          ]
+        }
+      },
+      "char_filter": {
+        "no_trailing_punctuation": {
+          "type": "pattern_replace",
+          "pattern": "[./;=,?]$",
+          "replacement": ""
+        }
+      },
       "normalizer": {
         "lowercase": {
           "type": "custom",
@@ -239,7 +258,13 @@
           "type": "text"
         },
         "title": {
-          "type": "text"
+          "type": "text",
+          "fields": {
+            "exact_value": {
+              "type": "text",
+              "analyzer": "keyword_no_trailing_punctuation"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
#### What does this PR do?

Our MARC records often insert specific trailing punctutation that prevent the noop of ElasticSearches keyword field from matching typical user input. This char_filter approach intends to allow better exact matches on the title fields so we can get better results in TIMDEX! (which will get a separate PR that leverages this new index).

#### Helpful background context

ugh

#### How can a reviewer manually see the effects of these changes?

There is an open TIMDEX! pr that uses an Elasticsearch index that this code was used to build.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-794

#### Requires Full Reindexing of all Sources?
YES

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
