### PR TITLE
Use timdex-prod instead of production for alias

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func main() {
 						return err
 					}
 					if len(old) != 1 {
-						return errors.New("Multiple indexes match. Unable to determine which index to update")
+						return errors.New("Multiple or zero indexes match. Unable to determine which index to update")
 					}
 					index = old[0]
 					println("Using exisitng index:", index)


### PR DESCRIPTION
#### What does this PR do?

This is proactive work to prevent confusion for future uses of our shared ES instance by labeling more clearly which application is using the resource rather than a generic like "production".

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-225

#### Requires Full Reindexing of all Sources?
NO, but will will need to manually promote the current aleph index and then update the Heroku ENV for timdex prod and staging to use `timdex-prod` instead of `production`.

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
