### PR TITLE
Change mapping type to _doc

### DIFF
--- a/config/es_record_mappings.json
+++ b/config/es_record_mappings.json
@@ -31,7 +31,7 @@
     }
   },
   "mappings": {
-    "Record": {
+    "_doc": {
       "properties": {
         "alternate_titles": {
           "type": "text"


### PR DESCRIPTION
The mapping type functionality is being removed in ES. In order to
upgrade to v7 we have to change to the default _doc mapping type. Once
we've done this and reindexed, we can remove the mapping type altogether
which will be necessary for v8.

#### Requires Full Reindexing of all Sources?
YES

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
