### PR TITLE
Archives parser updates

### DIFF
--- a/archives.go
+++ b/archives.go
@@ -54,46 +54,62 @@ func processXMLRecord(se xml.StartElement, decoder *xml.Decoder, out chan Record
 	decoder.DecodeElement(&ar, &se)
 
 	r := Record{}
-	r.Identifier = "MIT:archivespace:" + strings.Replace(ar.Metadata.Ead.Archdesc.Did.Unitid, " ", ".", -1)
 
-	id := ar.Header.Identifier
+	// Citation field
+	r.Citation = ar.Metadata.Ead.Archdesc.Prefercite.P.Text
+
+	// Contributor field
+	if len(ar.Metadata.Ead.Archdesc.Did.Origination) > 0 {
+		r.Contributor = eadContributors(ar)
+	}
+
+	//  Holdings field
+	var h []Holding
+	h = append(h, Holding{Location: ar.Metadata.Ead.Archdesc.Did.Physloc.Text})
+	r.Holdings = h
+
+	// Identifier field
+	r.Identifier = "MIT:archivesspace:" + strings.Replace(ar.Metadata.Ead.Archdesc.Did.Unitid, " ", ".", -1)
+
+	// Language field
+	if len(ar.Metadata.Ead.Archdesc.Did.Langmaterial) > 0 {
+		r.Language = eadLanguage(ar)
+	}
+
+	// Links field
+	r.Links = eadLinks(ar)
+
+	// Notes field
+	r.Notes = eadNotes(ar)
+
+	//  Physical Description field
+	if len(ar.Metadata.Ead.Archdesc.Did.Physdesc) > 0 {
+		r.PhysicalDescription = eadPhysicalDescription(ar)
+	}
+
+	// Publication Date field
+	r.PublicationDate = eadPublicationDate(ar)
+
+	// Source field
 	r.Source = "MIT ArchivesSpace"
+
+	// Source Link field
+	id := ar.Header.Identifier
 	linkIdentifier := strings.Split(id, "oai:mit/")[1]
 	r.SourceLink = "https://archivesspace.mit.edu" + linkIdentifier
 
-	r.PublicationDate = eadPublicationDate(ar)
+	// Subject field
+	r.Subject = eadSubjects(ar)
 
-	r.Title = ar.Metadata.Ead.Archdesc.Did.Unittitle.Text
-
+	// Summary field
 	if len(ar.Metadata.Ead.Archdesc.Did.Abstract) > 0 {
 		for _, a := range ar.Metadata.Ead.Archdesc.Did.Abstract {
 			r.Summary = append(r.Summary, a.Text)
 		}
 	}
 
-	r.Citation = ar.Metadata.Ead.Archdesc.Prefercite.P.Text
-
-	r.Links = eadLinks(ar)
-
-	if len(ar.Metadata.Ead.Archdesc.Did.Origination) > 0 {
-		r.Contributor = eadContributors(ar)
-	}
-
-	r.Subject = eadSubjects(ar)
-
-	var h []Holding
-	h = append(h, Holding{Location: ar.Metadata.Ead.Archdesc.Did.Physloc.Text})
-	r.Holdings = h
-
-	if len(ar.Metadata.Ead.Archdesc.Did.Langmaterial) > 0 {
-		r.Language = eadLanguage(ar)
-	}
-
-	if len(ar.Metadata.Ead.Archdesc.Did.Physdesc) > 0 {
-		r.PhysicalDescription = eadPhysicalDescription(ar)
-	}
-
-	r.Notes = eadNotes(ar)
+	// Title field
+	r.Title = ar.Metadata.Ead.Archdesc.Did.Unittitle.Text
 
 	out <- r
 }

--- a/archives.go
+++ b/archives.go
@@ -58,6 +58,9 @@ func processXMLRecord(se xml.StartElement, decoder *xml.Decoder, out chan Record
 	// Citation field
 	r.Citation = ar.Metadata.Ead.Archdesc.Prefercite.P.Text
 
+	// ContentType field
+	r.ContentType = "Archival " + ar.Metadata.Ead.Archdesc.Level
+
 	// Contributor field
 	if len(ar.Metadata.Ead.Archdesc.Did.Origination) > 0 {
 		r.Contributor = eadContributors(ar)
@@ -82,18 +85,18 @@ func processXMLRecord(se xml.StartElement, decoder *xml.Decoder, out chan Record
 	// Notes field
 	r.Notes = eadNotes(ar)
 
-	//  Physical Description field
+	//  PhysicalDescription field
 	if len(ar.Metadata.Ead.Archdesc.Did.Physdesc) > 0 {
 		r.PhysicalDescription = eadPhysicalDescription(ar)
 	}
 
-	// Publication Date field
+	// PublicationDate field
 	r.PublicationDate = eadPublicationDate(ar)
 
 	// Source field
 	r.Source = "MIT ArchivesSpace"
 
-	// Source Link field
+	// SourceLink field
 	id := ar.Header.Identifier
 	linkIdentifier := strings.Split(id, "oai:mit/")[1]
 	r.SourceLink = "https://archivesspace.mit.edu" + linkIdentifier

--- a/archives.go
+++ b/archives.go
@@ -168,17 +168,13 @@ func eadLinks(ar AspaceRecord) []Link {
 	var links []Link
 
 	dsc, _ := xmlquery.Parse(strings.NewReader(ar.Metadata.Ead.Archdesc.Dsc.Text))
-
 	dao := xmlquery.Find(dsc, "//dao")
 
 	for _, obj := range dao {
-
 		link := Link{
 			URL:  obj.SelectAttr("xlink:href"),
-			Text: obj.SelectAttr("xlink:title"),
-		}
-		if link.Kind == "" {
-			link.Kind = "unknown"
+			Text: obj.SelectElement("daodesc").SelectElement("p").InnerText(),
+			Kind: "Digital object",
 		}
 
 		// only keep links that start with http. This isn't ideal, but seems okay.

--- a/archives_test.go
+++ b/archives_test.go
@@ -68,7 +68,19 @@ func TestArchivesRecordParsing(t *testing.T) {
 
 	// Test Links field
 	if len(record.Links) != 234 {
-		t.Error("Expected 234, got", len(record.Links))
+		t.Error("Expected match, got", len(record.Links))
+	}
+
+	if record.Links[0].URL != "http://hdl.handle.net/1721.3/35646" {
+		t.Error("Expected match, got", record.Links[0].URL)
+	}
+
+	if record.Links[0].Text != "K.L. 3-8-55: 1955 March 8" {
+		t.Error("Expected match, got", record.Links[0].Text)
+	}
+
+	if record.Links[0].Kind != "Digital object" {
+		t.Error("Expected match, got", record.Links[0].Kind)
 	}
 
 	// Test PublicationDate field

--- a/archives_test.go
+++ b/archives_test.go
@@ -48,12 +48,16 @@ func TestArchivesRecordParsing(t *testing.T) {
 	}
 
 	// Test Contributor field
-	if record.Contributor[0].Value != "Lynch, Kevin, 1918-1984" {
-		t.Error("Expected match, got", record.Contributor[0].Value)
+	if len(record.Contributor) != 1 {
+		t.Error("Expected 1, got", len(record.Contributor))
 	}
 
-	if record.Contributor[0].Kind != "Person" {
-		t.Error("Expected match, got", record.Contributor[0].Kind)
+	if record.Contributor[0].Kind != "Creator" {
+		t.Error("Expected 'Creator', got", record.Contributor[0].Kind)
+	}
+
+	if record.Contributor[0].Value != "Lynch, Kevin, 1918-1984" {
+		t.Error("Expected 'Lynch, Kevin, 1918-1984', got", record.Contributor[0].Value)
 	}
 
 	// Test Holdings field

--- a/archives_test.go
+++ b/archives_test.go
@@ -42,6 +42,11 @@ func TestArchivesRecordParsing(t *testing.T) {
 		t.Error("Expected match, got", record.Citation)
 	}
 
+	// Test ContentType field
+	if record.ContentType != "Archival collection" {
+		t.Error("Expected match, got", record.ContentType)
+	}
+
 	// Test Contributor field
 	if record.Contributor[0].Value != "Lynch, Kevin, 1918-1984" {
 		t.Error("Expected match, got", record.Contributor[0].Value)
@@ -66,12 +71,12 @@ func TestArchivesRecordParsing(t *testing.T) {
 		t.Error("Expected 234, got", len(record.Links))
 	}
 
-	// Test Publication Date field
+	// Test PublicationDate field
 	if record.PublicationDate != "1934-1988" {
 		t.Error("Expected match, got", record.PublicationDate)
 	}
 
-	// Test Source Link field
+	// Test SourceLink field
 	if record.SourceLink != "https://archivesspace.mit.edu/repositories/2/resources/739" {
 		t.Error("Expected match, got", record.SourceLink)
 	}

--- a/archives_test.go
+++ b/archives_test.go
@@ -37,6 +37,12 @@ func TestArchivesRecordParsing(t *testing.T) {
 
 	record := <-out
 
+	// Test Citation field
+	if record.Citation != "Kevin Lynch papers, MC 208, box X. Massachusetts Institute of Technology, Department of Distinctive Collections, Cambridge, Massachusetts." {
+		t.Error("Expected match, got", record.Citation)
+	}
+
+	// Test Contributor field
 	if record.Contributor[0].Value != "Lynch, Kevin, 1918-1984" {
 		t.Error("Expected match, got", record.Contributor[0].Value)
 	}
@@ -45,27 +51,38 @@ func TestArchivesRecordParsing(t *testing.T) {
 		t.Error("Expected match, got", record.Contributor[0].Kind)
 	}
 
-	if record.Identifier != "MIT:archivespace:MC.0208" {
+	// Test Holdings field
+	if record.Holdings[0].Location != "Materials are stored off-site. Advance notice is required for use." {
+		t.Error("Expected match, got", record.Holdings[0].Location)
+	}
+
+	// Test Identifier field
+	if record.Identifier != "MIT:archivesspace:MC.0208" {
 		t.Error("Expected match, got", record.Identifier)
 	}
 
-	if record.Title != "Kevin Lynch papers" {
-		t.Error("Expected match, got", record.Title)
-	}
-
-	if len(record.Subject) != 8 {
-		t.Error("Expected match, got", len(record.Subject))
-	}
-
-	if record.PublicationDate != "1934-1988" {
-		t.Error("Expected match, got", record.PublicationDate)
-	}
-
+	// Test Links field
 	if len(record.Links) != 234 {
 		t.Error("Expected 234, got", len(record.Links))
 	}
 
-	if record.Holdings[0].Location != "Materials are stored off-site. Advance notice is required for use." {
-		t.Error("Expected match, got", record.Holdings[0].Location)
+	// Test Publication Date field
+	if record.PublicationDate != "1934-1988" {
+		t.Error("Expected match, got", record.PublicationDate)
+	}
+
+	// Test Source Link field
+	if record.SourceLink != "https://archivesspace.mit.edu/repositories/2/resources/739" {
+		t.Error("Expected match, got", record.SourceLink)
+	}
+
+	// Test Subject field
+	if len(record.Subject) != 8 {
+		t.Error("Expected match, got", len(record.Subject))
+	}
+
+	// Test Title field
+	if record.Title != "Kevin Lynch papers" {
+		t.Error("Expected match, got", record.Title)
 	}
 }

--- a/archives_test.go
+++ b/archives_test.go
@@ -39,12 +39,12 @@ func TestArchivesRecordParsing(t *testing.T) {
 
 	// Test Citation field
 	if record.Citation != "Kevin Lynch papers, MC 208, box X. Massachusetts Institute of Technology, Department of Distinctive Collections, Cambridge, Massachusetts." {
-		t.Error("Expected match, got", record.Citation)
+		t.Error("Expected 'Kevin Lynch papers, MC 208, box X. Massachusetts Institute of Technology, Department of Distinctive Collections, Cambridge, Massachusetts.', got", record.Citation)
 	}
 
 	// Test ContentType field
 	if record.ContentType != "Archival collection" {
-		t.Error("Expected match, got", record.ContentType)
+		t.Error("Expected 'Archival collection', got", record.ContentType)
 	}
 
 	// Test Contributor field
@@ -58,44 +58,62 @@ func TestArchivesRecordParsing(t *testing.T) {
 
 	// Test Holdings field
 	if record.Holdings[0].Location != "Materials are stored off-site. Advance notice is required for use." {
-		t.Error("Expected match, got", record.Holdings[0].Location)
+		t.Error("Expected 'Materials are stored off-site. Advance notice is required for use.', got", record.Holdings[0].Location)
 	}
 
 	// Test Identifier field
 	if record.Identifier != "MIT:archivesspace:MC.0208" {
-		t.Error("Expected match, got", record.Identifier)
+		t.Error("Expected 'MIT:archivesspace:MC.0208', got", record.Identifier)
+	}
+
+	// Test Language field
+	if len(record.Language) != 1 {
+		t.Error("Expected 1, got", len(record.Language))
+	}
+
+	if record.Language[0] != "English" {
+		t.Error("Expected 'English', got", record.Language[0])
 	}
 
 	// Test Links field
 	if len(record.Links) != 234 {
-		t.Error("Expected match, got", len(record.Links))
+		t.Error("Expected 234, got", len(record.Links))
 	}
 
 	if record.Links[0].URL != "http://hdl.handle.net/1721.3/35646" {
-		t.Error("Expected match, got", record.Links[0].URL)
+		t.Error("Expected 'http://hdl.handle.net/1721.3/35646', got", record.Links[0].URL)
 	}
 
 	if record.Links[0].Text != "K.L. 3-8-55: 1955 March 8" {
-		t.Error("Expected match, got", record.Links[0].Text)
+		t.Error("Expected 'K.L. 3-8-55: 1955 March 8', got", record.Links[0].Text)
 	}
 
 	if record.Links[0].Kind != "Digital object" {
-		t.Error("Expected match, got", record.Links[0].Kind)
+		t.Error("Expected 'Digital object', got", record.Links[0].Kind)
+	}
+
+	//Test PhysicalDescription field
+	if record.PhysicalDescription != "16.5 Cubic Feet; 12 record cartons, 8 manuscript boxes, 1 half manuscript box, 4 medium flat boxes, 1 large flat box, 3 small media boxes, 1 slide box and 2 loose drawings, 10 oversize folders" {
+		t.Error("Expected '16.5 Cubic Feet; 12 record cartons, 8 manuscript boxes, 1 half manuscript box, 4 medium flat boxes, 1 large flat box, 3 small media boxes, 1 slide box and 2 loose drawings, 10 oversize folders', got", record.PublicationDate)
 	}
 
 	// Test PublicationDate field
 	if record.PublicationDate != "1934-1988" {
-		t.Error("Expected match, got", record.PublicationDate)
+		t.Error("Expected '1934-1988', got", record.PublicationDate)
 	}
 
 	// Test SourceLink field
 	if record.SourceLink != "https://archivesspace.mit.edu/repositories/2/resources/739" {
-		t.Error("Expected match, got", record.SourceLink)
+		t.Error("Expected 'https://archivesspace.mit.edu/repositories/2/resources/739', got", record.SourceLink)
 	}
 
 	// Test Subject field
 	if len(record.Subject) != 8 {
-		t.Error("Expected match, got", len(record.Subject))
+		t.Error("Expected 8, got", len(record.Subject))
+	}
+
+	if record.Subject[0] != "Urban ecology" {
+		t.Error("Expected 'Urban ecology', got", record.Subject[0])
 	}
 
 	// Test Title field

--- a/config/aspace_code_mappings.yml
+++ b/config/aspace_code_mappings.yml
@@ -1,0 +1,1840 @@
+enumerations:
+  linked_event_archival_record_roles:
+    source: Source
+    outcome: Outcome
+    transfer: Transfer
+    context: Context
+    requested: Requested
+  linked_agent_archival_record_relators:
+    abr: Abridger
+    act: Actor
+    adi: Art director
+    adp: Adapter
+    anl: Analyst
+    anm: Animator
+    ann: Annotator
+    ape: Appellee
+    apl: Appellant
+    app: Applicant
+    arc: Architect
+    arr: Arranger
+    acp: Art copyist
+    art: Artist
+    ard: Artistic director
+    asg: Assignee
+    asn: Associated name
+    att: Attributed name
+    auc: Auctioneer
+    aut: Author
+    aqt: Author in quotations or text abstracts
+    aft: Author of afterword, colophon, etc.
+    aud: Author of dialog
+    aui: Author of introduction, etc.
+    aus: Author of screenplay, etc.
+    ato: Autographer
+    ant: Bibliographic antecedent
+    bnd: Binder
+    bdd: Binding designer
+    blw: Blurb writer
+    bkd: Book designer
+    bkp: Book producer
+    bjd: Bookjacket designer
+    bpd: Bookplate designer
+    bsl: Bookseller
+    brl: Braille embosser
+    brd: Broadcaster
+    cll: Calligrapher
+    ctg: Cartographer
+    cas: Caster
+    cns: Censor
+    chr: Choreographer
+    cng: Cinematographer
+    cli: Client
+    cor: Collection registrar
+    clb: Collaborator
+    col: Collector
+    clt: Collotyper
+    clr: Colorist
+    cmm: Commentator
+    cwt: Commentator for written text
+    com: Compiler
+    cpl: Complainant
+    cpt: Complainant-appellant
+    cpe: Complainant-appellee
+    cmp: Composer
+    cmt: Compositor
+    ccp: Conceptor
+    cnd: Conductor
+    con: Conservator
+    csl: Consultant
+    csp: Consultant to a project
+    cos: Contestant
+    cot: Contestant-appellant
+    coe: Contestant-appellee
+    cts: Contestee
+    ctt: Contestee-appellant
+    cte: Contestee-appellee
+    ctr: Contractor
+    ctb: Contributor
+    cpc: Copyright claimant
+    cph: Copyright holder
+    crr: Corrector
+    crp: Correspondent
+    cst: Costume designer
+    cou: Court governed
+    crt: Court reporter
+    cov: Cover designer
+    cre: Creator
+    cur: Curator of an exhibition
+    dnc: Dancer
+    dtc: Data contributor
+    dtm: Data manager
+    dte: Dedicatee
+    dto: Dedicator
+    dfd: Defendant
+    dft: Defendant-appellant
+    dfe: Defendant-appellee
+    dgg: Degree grantor
+    dgs: Degree supervisor
+    dln: Delineator
+    dpc: Depicted
+    dpt: Depositor
+    dsr: Designer
+    drt: Director
+    dis: Dissertant
+    dbp: Distribution place
+    dst: Distributor
+    dnr: Donor
+    drm: Draftsman
+    dub: Dubious author
+    edt: Editor
+    edc: Editor of compilation
+    edm: Editor of moving image work
+    elg: Electrician
+    elt: Electrotyper
+    enj: Enacting jurisdiction
+    eng: Engineer
+    egr: Engraver
+    etr: Etcher
+    evp: Event place
+    exp: Appraiser
+    fac: Facsimilist
+    fld: Field director
+    fmd: Film director
+    fds: Film distributor
+    flm: Film editor
+    fmp: Film producer
+    fmk: Filmmaker
+    fpy: First party
+    frg: Forger
+    fmo: Former owner
+    fnd: Funder
+    gis: Geographic information specialist
+    grt: Graphic technician
+    hnr: Honoree
+    hst: Host
+    his: Host institution
+    ilu: Illuminator
+    ill: Illustrator
+    ins: Inscriber
+    itr: Instrumentalist
+    ive: Interviewee
+    ivr: Interviewer
+    inv: Inventor
+    isb: Issuing body
+    jud: Judge
+    jug: Jurisdiction governed
+    lbr: Laboratory
+    ldr: Laboratory director
+    lsa: Landscape architect
+    led: Lead
+    len: Lender
+    lil: Libelant
+    lit: Libelant-appellant
+    lie: Libelant-appellee
+    lel: Libelee
+    let: Libelee-appellant
+    lee: Libelee-appellee
+    lbt: Librettist
+    lse: Licensee
+    lso: Licensor
+    lgd: Lighting designer
+    ltg: Lithographer
+    lyr: Lyricist
+    mfp: Manufacture place
+    mfr: Manufacturer
+    mrb: Marbler
+    mrk: Markup editor
+    med: Medium
+    mdc: Metadata contact
+    mte: Metal-engraver
+    mtk: Minute taker
+    mod: Moderator
+    mon: Monitor
+    mcp: Music copyist
+    msd: Musical director
+    mus: Musician
+    nrt: Narrator
+    osp: Onscreen presenter
+    opn: Opponent
+    orm: Organizer of meeting
+    org: Originator
+    oth: Other
+    own: Owner
+    pan: Panelist
+    ppm: Papermaker
+    pta: Patent applicant
+    pth: Patentee
+    pat: Patron
+    prf: Performer
+    pma: Permitting agency
+    pht: Photographer
+    ptf: Plaintiff
+    ptt: Plaintiff-appellant
+    pte: Plaintiff-appellee
+    plt: Platemaker
+    pra: Praeses
+    pre: Presenter
+    prt: Printer
+    pop: Printer of plates
+    prm: Printmaker
+    prc: Process contact
+    pro: Producer
+    prn: Production company
+    pmn: Production manager
+    prs: Production designer
+    prd: Production personnel
+    prp: Production place
+    prg: Programmer
+    pdr: Project director
+    pfr: Proofreader
+    prv: Provider
+    pup: Publication place
+    pbl: Publisher
+    pbd: Publishing director
+    ppt: Puppeteer
+    rdd: Radio director
+    rpc: Radio producer
+    rcp: Recipient
+    rce: Recording engineer
+    rcd: Recordist
+    red: Redaktor
+    ren: Renderer
+    rpt: Reporter
+    rps: Repository
+    rth: Research team head
+    rtm: Research team member
+    res: Researcher
+    rsp: Respondent
+    rst: Respondent-appellant
+    rse: Respondent-appellee
+    rpy: Responsible party
+    rsg: Restager
+    rsr: Restorationist
+    rev: Reviewer
+    rbr: Rubricator
+    sce: Scenarist
+    sad: Scientific advisor
+    scr: Scribe
+    scl: Sculptor
+    spy: Second party
+    sec: Secretary
+    sll: Seller
+    std: Set designer
+    stg: Setting
+    sgn: Signer
+    sng: Singer
+    sds: Sound designer
+    spk: Speaker
+    spn: Sponsor
+    sgd: Stage director
+    stm: Stage manager
+    stn: Standards body
+    str: Stereotyper
+    stl: Storyteller
+    sht: Supporting host
+    srv: Surveyor
+    tch: Teacher
+    tcd: Technical director
+    tld: Television director
+    tlp: Television producer
+    ths: Thesis advisor
+    trc: Transcriber
+    trl: Translator
+    tyd: Type designer
+    tyg: Typographer
+    uvp: University place
+    vdg: Videographer
+    vac: Voice actor
+    voc: Vocalist
+    wit: Witness
+    wde: Wood engraver
+    wdc: Woodcutter
+    wam: Writer of accompanying material
+    wac: Writer of added commentary
+    wal: Writer of added lyrics
+    wat: Writer of added text
+    win: Writer of introduction
+    wpr: Writer of preface
+    wst: Writer of supplementary textual content
+  linked_agent_event_roles:
+    authorizer: Authorizer
+    executing_program: Executing Program
+    implementer: Implementer
+    recipient: Recipient
+    requester: Requester
+    transmitter: Transmitter
+    validator: Validator
+  name_source:
+    cash: Canadian Subject Headings
+    ingest: Unspecified ingested source
+    lcshac: Library of Congress Children's Subject Headings
+    local: Local sources
+    lcnaf: Library of Congress Name Authority File
+    naf: NACO Authority File
+    nad: NAD / ARK II Name Authority Database
+    nal: National Agricultural Library subject headings
+    rvm: Répertoire de vedettes-matière
+    ram: Répertoire d'autorités RAMEAU
+    ulan: Union List of Artist Names
+  name_rule:
+    local: Local rules
+    aacr: Anglo-American Cataloging Rules
+    dacs: "Describing Archives: A Content Standard"
+    rda: Resource Description and Access
+  extent_extent_type:
+    cassettes: Cassettes
+    cubic_feet: Cubic Feet
+    files: Files
+    gigabytes: Gigabytes
+    leaves: Leaves
+    linear_feet: Linear Feet
+    megabytes: Megabytes
+    photographic_prints: Photographic Prints
+    photographic_slides: Photographic Slides
+    reels: Reels
+    sheets: Sheets
+    terabytes: Terabytes
+    volumes: Volumes
+  collection_management_processing_priority:
+    none: Not specified
+    high: High
+    medium: Medium
+    low: Low
+  collection_management_processing_status:
+    none: Not specified
+    new: New
+    in_progress: In Progress
+    completed: Completed
+  date_era:
+    ce: ce
+  date_calendar:
+    gregorian: Gregorian
+  digital_object_digital_object_type:
+    cartographic: Cartographic
+    mixed_materials: Mixed Materials
+    moving_image: Moving Image
+    notated_music: Notated Music
+    software_multimedia: Software, Multimedia
+    sound_recording: Sound Recording
+    sound_recording_musical: Sound Recording (Musical)
+    sound_recording_nonmusical: Sound Recording (Non-musical)
+    still_image: Still Image
+    text: Text
+  digital_object_level:
+    collection: Collection
+    work: Work
+    image: Image
+  event_event_type:
+    accession: Accession
+    accumulation: Accumulation
+    acknowledgement: Acknowledgement
+    acknowledgement_sent: Acknowledgement Sent
+    acknowledgement_received: Acknowledgement Received
+    agreement_received: Agreement Received
+    agreement_sent: Agreement Sent
+    agreement_signed: Agreement Signed
+    appraisal: Appraisal
+    assessment: Assessment
+    capture: Capture
+    cataloged: Cataloged
+    collection: Collection
+    compression: Compression
+    contribution: Contribution
+    component_transfer: Component Transfer
+    copyright_transfer: Copyright Transfer
+    custody_transfer: Custody Transfer
+    deaccession: Deaccession
+    decompression: Decompression
+    decryption: Decryption
+    deletion: Deletion
+    digital_signature_validation: Digital Signature Validation
+    fixity_check: Fixity Check
+    ingestion: Ingestion
+    message_digest_calculation: Message Digest Calculation
+    migration: Migration
+    normalization: Normalization
+    processed: Processed
+    processing_new: Processing New
+    processing_started: Processing Started
+    processing_in_progress: Processing in Progress
+    processing_completed: Processing Completed
+    publication: Publication
+    replication: Replication
+    request: Request
+    rights_transferred: Rights Transferred
+    validation: Validation
+    virus_check: Virus Check
+  resource_resource_type:
+    collection: Collection
+    publications: Publications
+    papers: Papers
+    records: Records
+  resource_finding_aid_description_rules:
+    aacr: Anglo-American Cataloguing Rules
+    cco: Cataloging Cultural Objects
+    dacs: "Describing Archives: A Content Standard"
+    rad: Rules for Archival Description
+    isadg: International Standard for Archival Description - General
+  resource_finding_aid_status:
+    completed: Completed
+    in_progress: In Progress
+    under_revision: Under Revision
+    unprocessed: Unprocessed
+  instance_instance_type:
+    accession: Accession
+    audio: Audio
+    books: Books
+    computer_disks: Computer Disks
+    digital_object: Digital Object
+    digital_object_link: Digital Object Link
+    graphic_materials: Graphic Materials
+    maps: Maps
+    microform: Microform
+    mixed_materials: Mixed Materials
+    moving_images: Moving Images
+    realia: Realia
+    text: Text
+  accession_acquisition_type:
+    deposit: Deposit
+    gift: Gift
+    purchase: Purchase
+    transfer: Transfer
+  accession_resource_type:
+    collection: Collection
+    publications: Publications
+    papers: Papers
+    records: Records
+  subject_source:
+    aat: "Art & Architecture Thesaurus"
+    cash: Canadian Subject Headings
+    gmgpc: "TGM II, Genre and physical characteristic terms"
+    ingest: Unspecified ingested source
+    lcsh: Library of Congress Subject Headings
+    lcshac: Library of Congress Children's Subject Headings
+    local: Local sources
+    mesh: Medical Subject Headings
+    nal: National Agricultural Library subject headings
+    rbgenr: "Genre Terms: A Thesaurus for Use in Rare Book and Special Collections Cataloguing"
+    rvm: Répertoire de vedettes-matière
+    ram: Répertoire d'autorités RAMEAU
+    tgn: Getty Thesaurus of Geographic Names
+    lcgft: Library of Congress Genre/Form Terms
+  event_outcome:
+    pass: Pass
+    partial pass: Partial Pass
+    fail: Fail
+    cancelled: Cancelled
+    fulfilled: Fulfilled
+    pending: Pending
+  agent_contact_salutation:
+    mr: Mr.
+    mrs: Mrs.
+    ms: Ms.
+    madame: Madame
+    sir: Sir
+  container_type:
+    box: Box
+    carton: Carton
+    case: Case
+    folder: Folder
+    frame: Frame
+    object: Object
+    page: Page
+    reel: Reel
+    volume: Volume
+  file_version_use_statement:
+    audio-clip: Audio-Clip
+    audio-master: Audio-Master
+    audio-master-edited: Audio-Master-Edited
+    audio-service: Audio-Service
+    audio-streaming: Audio-Streaming
+    image-master: Image-Master
+    image-master-edited: Image-Master-Edited
+    image-service: Image-Service
+    image-service-edited: Image-Service-Edited
+    image-thumbnail: Image-Thumbnail
+    text-codebook: Text-Codebook
+    text-data: Text-Data
+    text-data_definition: Text-Data Definition
+    text-georeference: Text-Georeference
+    text-ocr-edited: Text-Ocr-Edited
+    text-ocr-unedited: Text-Ocr-Unedited
+    text-tei-transcripted: Text-Tei-Transcripted
+    text-tei-translated: Text-Tei-Translated
+    video-clip: Video-Clip
+    video-master: Video-Master
+    video-master-edited: Video-Master-Edited
+    video-service: Video-Service
+    video-streaming: Video-Streaming
+  file_version_checksum_methods:
+    md5: MD5
+    sha-1: SHA-1
+    sha-256: SHA-256
+    sha-384: SHA-384
+    sha-512: SHA-512
+  language_iso639_2:
+    aar: Afar
+    abk: Abkhazian
+    ace: Achinese
+    ach: Acoli
+    ada: Adangme
+    ady: Adyghe; Adygei
+    afa: Afro-Asiatic languages
+    afh: Afrihili
+    afr: Afrikaans
+    ain: Ainu
+    aka: Akan
+    akk: Akkadian
+    alb: Albanian
+    ale: Aleut
+    alg: Algonquian languages
+    alt: Southern Altai
+    amh: Amharic
+    ang: "English, Old (ca.450-1100)"
+    anp: Angika
+    apa: Apache languages
+    ara: Arabic
+    arc: Official Aramaic (700-300 BCE); Imperial Aramaic (700-300 BCE)
+    arg: Aragonese
+    arm: Armenian
+    arn: Mapudungun; Mapuche
+    arp: Arapaho
+    art: Artificial languages
+    arw: Arawak
+    asm: Assamese
+    ast: Asturian; Bable; Leonese; Asturleonese
+    ath: Athapascan languages
+    aus: Australian languages
+    ava: Avaric
+    ave: Avestan
+    awa: Awadhi
+    aym: Aymara
+    aze: Azerbaijani
+    bad: Banda languages
+    bai: Bamileke languages
+    bak: Bashkir
+    bal: Baluchi
+    bam: Bambara
+    ban: Balinese
+    baq: Basque
+    bas: Basa
+    bat: Baltic languages
+    bej: Beja; Bedawiyet
+    bel: Belarusian
+    bem: Bemba
+    ben: Bengali
+    ber: Berber languages
+    bho: Bhojpuri
+    bih: Bihari languages
+    bik: Bikol
+    bin: Bini; Edo
+    bis: Bislama
+    bla: Siksika
+    bnt: Bantu (Other)
+    bos: Bosnian
+    bra: Braj
+    bre: Breton
+    btk: Batak languages
+    bua: Buriat
+    bug: Buginese
+    bul: Bulgarian
+    bur: Burmese
+    byn: Blin; Bilin
+    cad: Caddo
+    cai: Central American Indian languages
+    car: Galibi Carib
+    cat: Catalan; Valencian
+    cau: Caucasian languages
+    ceb: Cebuano
+    cel: Celtic languages
+    cha: Chamorro
+    chb: Chibcha
+    che: Chechen
+    chg: Chagatai
+    chi: Chinese
+    chk: Chuukese
+    chm: Mari
+    chn: Chinook jargon
+    cho: Choctaw
+    chp: Chipewyan; Dene Suline
+    chr: Cherokee
+    chu: Church Slavic; Old Slavonic; Church Slavonic; Old Bulgarian; Old Church Slavonic
+    chv: Chuvash
+    chy: Cheyenne
+    cmc: Chamic languages
+    cnr: Montenegrin
+    cop: Coptic
+    cor: Cornish
+    cos: Corsican
+    cpe: "Creoles and pidgins, English-based"
+    cpf: "Creoles and pidgins, French-based"
+    cpp: "Creoles and pidgins, Portuguese-based"
+    cre: Cree
+    crh: Crimean Tatar; Crimean Turkish
+    crp: Creoles and pidgins
+    csb: Kashubian
+    cus: Cushitic languages
+    cze: Czech
+    dak: Dakota
+    dan: Danish
+    dar: Dargwa
+    day: Land Dayak languages
+    del: Delaware
+    den: Slave (Athapascan)
+    dgr: Dogrib
+    din: Dinka
+    div: Divehi; Dhivehi; Maldivian
+    doi: Dogri
+    dra: Dravidian languages
+    dsb: Lower Sorbian
+    dua: Duala
+    dum: "Dutch, Middle (ca.1050-1350)"
+    dut: Dutch; Flemish
+    dyu: Dyula
+    dzo: Dzongkha
+    efi: Efik
+    egy: Egyptian (Ancient)
+    eka: Ekajuk
+    elx: Elamite
+    eng: English
+    enm: "English, Middle (1100-1500)"
+    epo: Esperanto
+    est: Estonian
+    ewe: Ewe
+    ewo: Ewondo
+    fan: Fang
+    fao: Faroese
+    fat: Fanti
+    fij: Fijian
+    fil: Filipino; Pilipino
+    fin: Finnish
+    fiu: Finno-Ugrian languages
+    fon: Fon
+    fre: French
+    frm: "French, Middle (ca.1400-1600)"
+    fro: "French, Old (842-ca.1400)"
+    frr: Northern Frisian
+    frs: Eastern Frisian
+    fry: Western Frisian
+    ful: Fulah
+    fur: Friulian
+    gaa: Ga
+    gay: Gayo
+    gba: Gbaya
+    gem: Germanic languages
+    geo: Georgian
+    ger: German
+    gez: Geez
+    gil: Gilbertese
+    gla: Gaelic; Scottish Gaelic
+    gle: Irish
+    glg: Galician
+    glv: Manx
+    gmh: "German, Middle High (ca.1050-1500)"
+    goh: "German, Old High (ca.750-1050)"
+    gon: Gondi
+    gor: Gorontalo
+    got: Gothic
+    grb: Grebo
+    grc: "Greek, Ancient (to 1453)"
+    gre: "Greek, Modern (1453-)"
+    grn: Guarani
+    gsw: Swiss German; Alemannic; Alsatian
+    guj: Gujarati
+    gwi: Gwich'in
+    hai: Haida
+    hat: Haitian; Haitian Creole
+    hau: Hausa
+    haw: Hawaiian
+    heb: Hebrew
+    her: Herero
+    hil: Hiligaynon
+    him: Himachali languages; Western Pahari languages
+    hin: Hindi
+    hit: Hittite
+    hmn: Hmong; Mong
+    hmo: Hiri Motu
+    hrv: Croatian
+    hsb: Upper Sorbian
+    hun: Hungarian
+    hup: Hupa
+    iba: Iban
+    ibo: Igbo
+    ice: Icelandic
+    ido: Ido
+    iii: Sichuan Yi; Nuosu
+    ijo: Ijo languages
+    iku: Inuktitut
+    ile: Interlingue; Occidental
+    ilo: Iloko
+    ina: Interlingua (International Auxiliary Language Association)
+    inc: Indic languages
+    ind: Indonesian
+    ine: Indo-European languages
+    inh: Ingush
+    ipk: Inupiaq
+    ira: Iranian languages
+    iro: Iroquoian languages
+    ita: Italian
+    jav: Javanese
+    jbo: Lojban
+    jpn: Japanese
+    jpr: Judeo-Persian
+    jrb: Judeo-Arabic
+    kaa: Kara-Kalpak
+    kab: Kabyle
+    kac: Kachin; Jingpho
+    kal: Kalaallisut; Greenlandic
+    kam: Kamba
+    kan: Kannada
+    kar: Karen languages
+    kas: Kashmiri
+    kau: Kanuri
+    kaw: Kawi
+    kaz: Kazakh
+    kbd: Kabardian
+    kha: Khasi
+    khi: Khoisan languages
+    khm: Central Khmer
+    kho: Khotanese; Sakan
+    kik: Kikuyu; Gikuyu
+    kin: Kinyarwanda
+    kir: Kirghiz; Kyrgyz
+    kmb: Kimbundu
+    kok: Konkani
+    kom: Komi
+    kon: Kongo
+    kor: Korean
+    kos: Kosraean
+    kpe: Kpelle
+    krc: Karachay-Balkar
+    krl: Karelian
+    kro: Kru languages
+    kru: Kurukh
+    kua: Kuanyama; Kwanyama
+    kum: Kumyk
+    kur: Kurdish
+    kut: Kutenai
+    lad: Ladino
+    lah: Lahnda
+    lam: Lamba
+    lao: Lao
+    lat: Latin
+    lav: Latvian
+    lez: Lezghian
+    lim: Limburgan; Limburger; Limburgish
+    lin: Lingala
+    lit: Lithuanian
+    lol: Mongo
+    loz: Lozi
+    ltz: Luxembourgish; Letzeburgesch
+    lua: Luba-Lulua
+    lub: Luba-Katanga
+    lug: Ganda
+    lui: Luiseno
+    lun: Lunda
+    luo: Luo (Kenya and Tanzania)
+    lus: Lushai
+    mac: Macedonian
+    mad: Madurese
+    mag: Magahi
+    mah: Marshallese
+    mai: Maithili
+    mak: Makasar
+    mal: Malayalam
+    man: Mandingo
+    mao: Maori
+    map: Austronesian languages
+    mar: Marathi
+    mas: Masai
+    may: Malay
+    mdf: Moksha
+    mdr: Mandar
+    men: Mende
+    mga: "Irish, Middle (900-1200)"
+    mic: Mi'kmaq; Micmac
+    min: Minangkabau
+    mis: Uncoded languages
+    mkh: Mon-Khmer languages
+    mlg: Malagasy
+    mlt: Maltese
+    mnc: Manchu
+    mni: Manipuri
+    mno: Manobo languages
+    moh: Mohawk
+    mon: Mongolian
+    mos: Mossi
+    mul: Multiple languages
+    mun: Munda languages
+    mus: Creek
+    mwl: Mirandese
+    mwr: Marwari
+    myn: Mayan languages
+    myv: Erzya
+    nah: Nahuatl languages
+    nai: North American Indian languages
+    nap: Neapolitan
+    nau: Nauru
+    nav: Navajo; Navaho
+    nbl: "Ndebele, South; South Ndebele"
+    nde: "Ndebele, North; North Ndebele"
+    ndo: Ndonga
+    nds: "Low German; Low Saxon; German, Low; Saxon, Low"
+    nep: Nepali
+    new: Nepal Bhasa; Newari
+    nia: Nias
+    nic: Niger-Kordofanian languages
+    niu: Niuean
+    nno: "Norwegian Nynorsk; Nynorsk, Norwegian"
+    nob: "Norwegian Bokmål; Bokmål, Norwegian"
+    nog: Nogai
+    non: "Norse, Old"
+    nor: Norwegian
+    nqo: N'Ko
+    nso: Pedi; Sepedi; Northern Sotho
+    nub: Nubian languages
+    nwc: Classical Newari; Old Newari; Classical Nepal Bhasa
+    nya: Chichewa; Chewa; Nyanja
+    nym: Nyamwezi
+    nyn: Nyankole
+    nyo: Nyoro
+    nzi: Nzima
+    oci: Occitan (post 1500); Provençal
+    oji: Ojibwa
+    ori: Oriya
+    orm: Oromo
+    osa: Osage
+    oss: Ossetian; Ossetic
+    ota: "Turkish, Ottoman (1500-1928)"
+    oto: Otomian languages
+    paa: Papuan languages
+    pag: Pangasinan
+    pal: Pahlavi
+    pam: Pampanga; Kapampangan
+    pan: Panjabi; Punjabi
+    pap: Papiamento
+    pau: Palauan
+    peo: "Persian, Old (ca.600-400 B.C.)"
+    per: Persian
+    phi: Philippine languages
+    phn: Phoenician
+    pli: Pali
+    pol: Polish
+    pon: Pohnpeian
+    por: Portuguese
+    pra: Prakrit languages
+    pro: "Provençal, Old (to 1500)"
+    pus: Pushto; Pashto
+    que: Quechua
+    raj: Rajasthani
+    rap: Rapanui
+    rar: Rarotongan; Cook Islands Maori
+    roa: Romance languages
+    roh: Romansh
+    rom: Romany
+    rum: Romanian; Moldavian; Moldovan
+    run: Rundi
+    rup: Aromanian; Arumanian; Macedo-Romanian
+    rus: Russian
+    sad: Sandawe
+    sag: Sango
+    sah: Yakut
+    sai: South American Indian (Other)
+    sal: Salishan languages
+    sam: Samaritan Aramaic
+    san: Sanskrit
+    sas: Sasak
+    sat: Santali
+    scn: Sicilian
+    sco: Scots
+    sel: Selkup
+    sem: Semitic languages
+    sga: "Irish, Old (to 900)"
+    sgn: Sign Languages
+    shn: Shan
+    sid: Sidamo
+    sin: Sinhala; Sinhalese
+    sio: Siouan languages
+    sit: Sino-Tibetan languages
+    sla: Slavic languages
+    slo: Slovak
+    slv: Slovenian
+    sma: Southern Sami
+    sme: Northern Sami
+    smi: Sami languages
+    smj: Lule Sami
+    smn: Inari Sami
+    smo: Samoan
+    sms: Skolt Sami
+    sna: Shona
+    snd: Sindhi
+    snk: Soninke
+    sog: Sogdian
+    som: Somali
+    son: Songhai languages
+    sot: "Sotho, Southern"
+    spa: Spanish; Castilian
+    srd: Sardinian
+    srn: Sranan Tongo
+    srp: Serbian
+    srr: Serer
+    ssa: Nilo-Saharan languages
+    ssw: Swati
+    suk: Sukuma
+    sun: Sundanese
+    sus: Susu
+    sux: Sumerian
+    swa: Swahili
+    swe: Swedish
+    syc: Classical Syriac
+    syr: Syriac
+    tah: Tahitian
+    tai: Tai languages
+    tam: Tamil
+    tat: Tatar
+    tel: Telugu
+    tem: Timne
+    ter: Tereno
+    tet: Tetum
+    tgk: Tajik
+    tgl: Tagalog
+    tha: Thai
+    tib: Tibetan
+    tig: Tigre
+    tir: Tigrinya
+    tiv: Tiv
+    tkl: Tokelau
+    tlh: Klingon; tlhIngan-Hol
+    tli: Tlingit
+    tmh: Tamashek
+    tog: Tonga (Nyasa)
+    ton: Tonga (Tonga Islands)
+    tpi: Tok Pisin
+    tsi: Tsimshian
+    tsn: Tswana
+    tso: Tsonga
+    tuk: Turkmen
+    tum: Tumbuka
+    tup: Tupi languages
+    tur: Turkish
+    tut: Altaic languages
+    tvl: Tuvalu
+    twi: Twi
+    tyv: Tuvinian
+    udm: Udmurt
+    uga: Ugaritic
+    uig: Uighur; Uyghur
+    ukr: Ukrainian
+    umb: Umbundu
+    und: Undetermined
+    urd: Urdu
+    uzb: Uzbek
+    vai: Vai
+    ven: Venda
+    vie: Vietnamese
+    vol: Volapük
+    vot: Votic
+    wak: Wakashan languages
+    wal: Walamo
+    war: Waray
+    was: Washo
+    wel: Welsh
+    wen: Sorbian languages
+    wln: Walloon
+    wol: Wolof
+    xal: Kalmyk; Oirat
+    xho: Xhosa
+    yao: Yao
+    yap: Yapese
+    yid: Yiddish
+    yor: Yoruba
+    ypk: Yupik languages
+    zap: Zapotec
+    zbl: Blissymbols; Blissymbolics; Bliss
+    zen: Zenaga
+    zgh: Standard Moroccan Tamazight
+    zha: Zhuang; Chuang
+    znd: Zande languages
+    zul: Zulu
+    zun: Zuni
+    zxx: No linguistic content; Not applicable
+    zza: Zaza; Dimili; Dimli; Kirdki; Kirmanjki; Zazaki
+  script_iso15924:
+    Adlm: Adlam
+    Afak: Afaka
+    Aghb: Caucasian Albanian
+    Ahom: Ahom, Tai Ahom
+    Arab: Arabic
+    Aran: Arabic (Nastaliq variant)
+    Armi: Imperial Aramaic
+    Armn: Armenian
+    Avst: Avestan
+    Bali: Balinese
+    Bamu: Bamum
+    Bass: Bassa Vah
+    Batk: Batak
+    Beng: Bengali (Bangla)
+    Bhks: Bhaiksuki
+    Blis: Blissymbols
+    Bopo: Bopomofo
+    Brah: Brahmi
+    Brai: Braille
+    Bugi: Buginese
+    Buhd: Buhid
+    Cakm: Chakma
+    Cans: Unified Canadian Aboriginal Syllabics
+    Cari: Carian
+    Cham: Cham
+    Cher: Cherokee
+    Cirt: Cirth
+    Copt: Coptic
+    Cpmn: Cypro-Minoan
+    Cprt: Cypriot syllabary
+    Cyrl: Cyrillic
+    Cyrs: Cyrillic (Old Church Slavonic variant)
+    Deva: Devanagari (Nagari)
+    Dogr: Dogra
+    Dsrt: Deseret (Mormon)
+    Dupl: Duployan shorthand, Duployan stenography
+    Egyd: Egyptian demotic
+    Egyh: Egyptian hieratic
+    Egyp: Egyptian hieroglyphs
+    Elba: Elbasan
+    Elym: Elymaic
+    Ethi: Ethiopic (Geʻez)
+    Geok: Khutsuri (Asomtavruli and Nuskhuri)
+    Geor: Georgian (Mkhedruli and Mtavruli)
+    Glag: Glagolitic
+    Gong: Gunjala Gondi
+    Gonm: Masaram Gondi
+    Goth: Gothic
+    Gran: Grantha
+    Grek: Greek
+    Gujr: Gujarati
+    Guru: Gurmukhi
+    Hanb: Han with Bopomofo (alias for Han + Bopomofo)
+    Hang: Hangul (Hangŭl, Hangeul)
+    Hani: Han (Hanzi, Kanji, Hanja)
+    Hano: Hanunoo (Hanunóo)
+    Hans: Han (Simplified variant)
+    Hant: Han (Traditional variant)
+    Hatr: Hatran
+    Hebr: Hebrew
+    Hira: Hiragana
+    Hluw: Anatolian Hieroglyphs (Luwian Hieroglyphs, Hittite Hieroglyphs)
+    Hmng: Pahawh Hmong
+    Hmnp: Nyiakeng Puachue Hmong
+    Hrkt: Japanese syllabaries (alias for Hiragana + Katakana)
+    Hung: Old Hungarian (Hungarian Runic)
+    Inds: Indus (Harappan)
+    Ital: Old Italic (Etruscan, Oscan, etc.)
+    Jamo: Jamo (alias for Jamo subset of Hangul)
+    Java: Javanese
+    Jpan: Japanese (alias for Han + Hiragana + Katakana)
+    Jurc: Jurchen
+    Kali: Kayah Li
+    Kana: Katakana
+    Khar: Kharoshthi
+    Khmr: Khmer
+    Khoj: Khojki
+    Kitl: Khitan large script
+    Kits: Khitan small script
+    Knda: Kannada
+    Kore: Korean (alias for Hangul + Han)
+    Kpel: Kpelle
+    Kthi: Kaithi
+    Lana: Tai Tham (Lanna)
+    Laoo: Lao
+    Latf: Latin (Fraktur variant)
+    Latg: Latin (Gaelic variant)
+    Latn: Latin
+    Leke: Leke
+    Lepc: Lepcha (Róng)
+    Limb: Limbu
+    Lina: Linear A
+    Linb: Linear B
+    Lisu: Lisu (Fraser)
+    Loma: Loma
+    Lyci: Lycian
+    Lydi: Lydian
+    Mahj: Mahajani
+    Maka: Makasar
+    Mand: Mandaic, Mandaean
+    Mani: Manichaean
+    Marc: Marchen
+    Maya: Mayan hieroglyphs
+    Medf: Medefaidrin (Oberi Okaime, Oberi Ɔkaimɛ)
+    Mend: Mende Kikakui
+    Merc: Meroitic Cursive
+    Mero: Meroitic Hieroglyphs
+    Mlym: Malayalam
+    Modi: Modi, Moḍī
+    Mong: Mongolian
+    Moon: Moon (Moon code, Moon script, Moon type)
+    Mroo: Mro, Mru
+    Mtei: Meitei Mayek (Meithei, Meetei)
+    Mult: Multani
+    Mymr: Myanmar (Burmese)
+    Nand: Nandinagari
+    Narb: Old North Arabian (Ancient North Arabian)
+    Nbat: Nabataean
+    Newa: Newa, Newar, Newari, Nepāla lipi
+    Nkdb: Naxi Dongba (na²¹ɕi³³ to³³ba²¹, Nakhi Tomba)
+    Nkgb: Naxi Geba (na²¹ɕi³³ gʌ²¹ba²¹, 'Na-'Khi ²Ggŏ-¹baw, Nakhi Geba)
+    Nkoo: N’Ko
+    Nshu: Nüshu
+    Ogam: Ogham
+    Olck: Ol Chiki (Ol Cemet’, Ol, Santali)
+    Orkh: Old Turkic, Orkhon Runic
+    Orya: Oriya (Odia)
+    Osge: Osage
+    Osma: Osmanya
+    Palm: Palmyrene
+    Pauc: Pau Cin Hau
+    Perm: Old Permic
+    Phag: Phags-pa
+    Phli: Inscriptional Pahlavi
+    Phlp: Psalter Pahlavi
+    Phlv: Book Pahlavi
+    Phnx: Phoenician
+    Plrd: Miao (Pollard)
+    Piqd: Klingon (KLI pIqaD)
+    Prti: Inscriptional Parthian
+    Qaaa: Reserved for private use (start)
+    Qabx: Reserved for private use (end)
+    Rjng: Rejang (Redjang, Kaganga)
+    Rohg: Hanifi Rohingya
+    Roro: Rongorongo
+    Runr: Runic
+    Samr: Samaritan
+    Sara: Sarati
+    Sarb: Old South Arabian
+    Saur: Saurashtra
+    Sgnw: SignWriting
+    Shaw: Shavian (Shaw)
+    Shrd: Sharada, Śāradā
+    Shui: Shuishu
+    Sidd: Siddham, Siddhaṃ, Siddhamātṛkā
+    Sind: Khudawadi, Sindhi
+    Sinh: Sinhala
+    Sogd: Sogdian
+    Sogo: Old Sogdian
+    Sora: Sora Sompeng
+    Soyo: Soyombo
+    Sund: Sundanese
+    Sylo: Syloti Nagri
+    Syrc: Syriac
+    Syre: Syriac (Estrangelo variant)
+    Syrj: Syriac (Western variant)
+    Syrn: Syriac (Eastern variant)
+    Tagb: Tagbanwa
+    Takr: Takri, Ṭākrī, Ṭāṅkrī
+    Tale: Tai Le
+    Talu: New Tai Lue
+    Taml: Tamil
+    Tang: Tangut
+    Tavt: Tai Viet
+    Telu: Telugu
+    Teng: Tengwar
+    Tfng: Tifinagh (Berber)
+    Tglg: Tagalog (Baybayin, Alibata)
+    Thaa: Thaana
+    Thai: Thai
+    Tibt: Tibetan
+    Tirh: Tirhuta
+    Ugar: Ugaritic
+    Vaii: Vai
+    Visp: Visible Speech
+    Wara: Warang Citi (Varang Kshiti)
+    Wcho: Wancho
+    Wole: Woleai
+    Xpeo: Old Persian
+    Xsux: Cuneiform, Sumero-Akkadian
+    Yiii: Yi
+    Zanb: Zanabazar Square (Zanabazarin Dörböljin Useg, Xewtee Dörböljin Bicig, Horizontal Square Script)
+    Zinh: Code for inherited script
+    Zmth: Mathematical notation
+    Zsye: Symbols (Emoji variant)
+    Zsym: Symbols
+    Zxxx: Code for unwritten documents
+    Zyyy: Code for undetermined script
+    Zzzz: Code for uncoded script
+  archival_record_level:
+    class: Class
+    collection: Collection
+    file: File
+    fonds: Fonds
+    item: Item
+    otherlevel: Other Level
+    recordgrp: Record Group
+    series: Series
+    subfonds: Sub-Fonds
+    subgrp: Sub-Group
+    subseries: Sub-Series
+  container_location_status:
+    current: Current
+    previous: Previous
+  date_type:
+    expression: Expression
+    single: Single
+    bulk: Bulk Dates
+    inclusive: Inclusive Dates
+    range: Range
+  date_label:
+    record_keeping: Record Keeping
+    broadcast: Broadcast
+    copyright: Copyright
+    creation: Creation
+    deaccession: Deaccession
+    agent_relation: Agent Relation
+    digitized: Digitized
+    existence: Existence
+    event: Event
+    issued: Issued
+    modified: Modified
+    publication: Publication
+    usage: Usage
+    other: Other
+  date_certainty:
+    approximate: Approximate
+    inferred: Inferred
+    questionable: Questionable
+  extent_portion:
+    whole: Whole
+    part: Part
+  deaccession_scope:
+    whole: Whole
+    part: Part
+  file_version_xlink_actuate_attribute:
+    none: none
+    other: other
+    onLoad: onLoad
+    onRequest: onRequest
+  file_version_xlink_show_attribute:
+    new: new
+    replace: replace
+    embed: embed
+    other: other
+    none: none
+  file_version_file_format_name:
+    aiff: Audio Interchange File Format
+    avi: Audio/Video Interleaved Format
+    gif: Graphics Interchange Format
+    jpeg: JPEG File Interchange Format
+    mp3: MPEG Audio Layer 3
+    pdf: Portable Document Format
+    tiff: Tagged Image File Format
+    txt: Plain Text File
+  location_temporary:
+    conservation: Conservation
+    exhibit: Exhibit
+    loan: Loan
+    reading_room: Reading Room
+  name_person_name_order:
+    direct: Direct
+    inverted: Indirect
+  country_iso_3166:
+    AF: Afghanistan
+    AX: Åland Islands
+    AL: Albania
+    DZ: Algeria
+    AS: American Samoa
+    AD: Andorra
+    AO: Angola
+    AI: Anguilla
+    AQ: Antarctica
+    AG: Antigua and Barbuda
+    AR: Argentina
+    AM: Armenia
+    AW: Aruba
+    AU: Australia
+    AT: Austria
+    AZ: Azerbaijan
+    BS: Bahamas
+    BH: Bahrain
+    BD: Bangladesh
+    BB: Barbados
+    BY: Belarus
+    BE: Belgium
+    BZ: Belize
+    BJ: Benin
+    BM: Bermuda
+    BT: Bhutan
+    BO: Bolivia
+    BQ: "Bonaire, Sint Eustatius and Saba"
+    BA: Bosnia and Herzegovina
+    BW: Botswana
+    BV: Bouvet Island
+    BR: Brazil
+    IO: British Indian Ocean Territory
+    BN: Brunei Darussalam
+    BG: Bulgaria
+    BF: Burkina Faso
+    BI: Burundi
+    KH: Cambodia
+    CM: Cameroon
+    CA: Canada
+    CV: Cape Verde
+    KY: Cayman Islands
+    CF: Central African Republic
+    TD: Chad
+    CL: Chile
+    CN: China
+    CX: Christmas island
+    CC: Cocos (Keeling) Islands
+    CO: Colombia
+    KM: Comoros
+    CG: Congo
+    CD: Democratic Republic of the Congo
+    CK: Cook Islands
+    CR: Costa Rica
+    CI: Côte d'Ivoire
+    HR: Croatia
+    CU: Cuba
+    CW: Curaçao
+    CY: Cyprus
+    CZ: Czech Republic
+    DK: Denmark
+    DJ: Djibouti
+    DM: Dominica
+    DO: Dominican Republic
+    EC: Ecuador
+    EG: Egypt
+    SV: El Salvador
+    GQ: Equatorial Guinea
+    ER: Eritrea
+    EE: Estonia
+    ET: Ethiopia
+    FK: Falkland Islands (Malvinas)
+    FO: Faroe Islands
+    FJ: Fiji
+    FI: Finland
+    FR: France
+    GF: French Guiana
+    PF: French Polynesia
+    TF: French Southern Territories
+    GA: Gabon
+    GM: Gambia
+    GE: Georgia
+    DE: Germany
+    GH: Ghana
+    GI: Gibraltar
+    GR: Greece
+    GL: Greenland
+    GD: Grenada
+    GP: Guadeloupe
+    GU: Guam
+    GT: Guatemala
+    GG: Guernsey
+    GN: Guinea
+    GW: Guinea-Bissau
+    GY: Guyana
+    HT: Haiti
+    HM: Heard Island and Mcdonald Islands
+    VA: Holy See (Vatican City State)
+    HN: Honduras
+    HK: Hong Kong
+    HU: Hungary
+    IS: Iceland
+    IN: India
+    ID: Indonesia
+    IR: "Iran, Islamic Republic of"
+    IQ: Iraq
+    IE: Ireland
+    IM: Isle of Man
+    IL: Israel
+    IT: Italy
+    JM: Jamaica
+    JP: Japan
+    JE: Jersey
+    JO: Jordan
+    KZ: Kazakhstan
+    KE: Kenya
+    KI: Kiribati
+    KP: "Korea, Democratic People's Republic of"
+    KR: "Korea, Republic of"
+    KW: Kuwait
+    KG: Kyrgyzstan
+    LA: "Lao People's Democratic Republic"
+    LV: Latvia
+    LB: Lebanon
+    LS: Lesotho
+    LR: Liberia
+    LY: Libya
+    LI: Liechtenstein
+    LT: Lithuania
+    LU: Luxembourg
+    MO: Macao
+    MK: "Macedonia, Former Yugoslav Republic of"
+    MG: Madagascar
+    MW: Malawi
+    MY: Malaysia
+    MV: Maldives
+    ML: Mali
+    MT: Malta
+    MH: Marshall Islands
+    MQ: Martinique
+    MR: Mauritania
+    MU: Mauritius
+    YT: Mayotte
+    MX: Mexico
+    FM: "Micronesia, Federated States of"
+    MD: "Moldova, Republic of"
+    MC: Monaco
+    MN: Mongolia
+    ME: Montenegro
+    MS: Montserrat
+    MA: Morocco
+    MZ: Mozambique
+    MM: Myanmar
+    NA: Namibia
+    NR: Nauru
+    NP: Nepal
+    NL: Netherlands
+    NC: New Caledonia
+    NZ: New Zealand
+    NI: Nicaragua
+    NE: Niger
+    NG: Nigeria
+    NU: Niue
+    NF: Norfolk Island
+    MP: Northern Mariana Islands
+    "NO": Norway
+    OM: Oman
+    PK: Pakistan
+    PW: Palau
+    PS: "Palestinian Territory, Occupied"
+    PA: Panama
+    PG: Papua New Guinea
+    PY: Paraguay
+    PE: Peru
+    PH: Philippines
+    PN: Pitcairn
+    PL: Poland
+    PT: Portugal
+    PR: Puerto rico
+    QA: Qatar
+    RE: Réunion
+    RO: Romania
+    RU: Russian Federation
+    RW: Rwanda
+    BL: Saint Barthélemy
+    SH: "Saint Helena, Ascension and Tristan da Cunha"
+    KN: Saint Kitts and Nevis
+    LC: Saint Lucia
+    MF: Saint Martin (French Part)
+    PM: Saint Pierre and Miquelon
+    VC: Saint Vincent and the Grenadines
+    WS: Samoa
+    SM: San Marino
+    ST: Sao Tome and Principe
+    SA: Saudi Arabia
+    SN: Senegal
+    RS: Serbia
+    SC: Seychelles
+    SL: Sierra Leone
+    SG: Singapore
+    SX: Sint Maarten (Dutch Part)
+    SK: Slovakia
+    SI: Slovenia
+    SB: Solomon Islands
+    SO: Somalia
+    ZA: South Africa
+    GS: South Georgia and the South Sandwich Islands
+    SS: South Sudan
+    ES: Spain
+    LK: Sri Lanka
+    SD: Sudan
+    SR: Suriname
+    SJ: Svalbard and Jan Mayen
+    SZ: Swaziland
+    SE: Sweden
+    CH: Switzerland
+    SY: Syrian Arab Republic
+    TW: "Taiwan, Province of China"
+    TJ: Tajikistan
+    TZ: "Tanzania, United Republic of"
+    TH: Thailand
+    TL: Timor-Leste
+    TG: Togo
+    TK: Tokelau
+    TO: Tonga
+    TT: Trinidad and Tobago
+    TN: Tunisia
+    TR: Turkey
+    TM: Turkmenistan
+    TC: Turks and Caicos Islands
+    TV: Tuvalu
+    UG: Uganda
+    UA: Ukraine
+    AE: United Arab Emirates
+    GB: United Kingdom
+    US: United States
+    UM: United States Minor Outlying Islands
+    UY: Uruguay
+    UZ: Uzbekistan
+    VU: Vanuatu
+    VE: Venezuela
+    VN: Viet Nam
+    VG: "Virgin Islands, British"
+    VI: "Virgin Islands, U.S."
+    WF: Wallis and Futuna
+    EH: Western Sahara
+    YE: Yemen
+    ZM: Zambia
+    ZW: Zimbabwe
+  rights_statement_act_type:
+    delete: Delete
+    disseminate: Disseminate
+    migrate: Migrate
+    modify: Modify
+    replicate: Replicate
+    use: Use
+  rights_statement_act_restriction:
+    allow: Allow
+    disallow: Disallow
+    conditional: Conditional
+  rights_statement_rights_type:
+    copyright: Copyright
+    license: License
+    statute: Statute
+    other: Other
+  rights_statement_ip_status:
+    copyrighted: Copyrighted
+    public_domain: Public Domain
+    unknown: Unknown
+  rights_statement_other_rights_basis:
+    donor: Donor
+    policy: Policy
+  subject_term_type:
+    cultural_context: Cultural context
+    function: Function
+    geographic: Geographic
+    genre_form: "Genre / Form"
+    occupation: Occupation
+    style_period: "Style / Period"
+    technique: Technique
+    temporal: Temporal
+    topical: Topical
+    uniform_title: Uniform Title
+  _note_types: &note_type_definitions
+    accessrestrict: Conditions Governing Access
+    accruals: Accruals
+    acqinfo: Immediate Source of Acquisition
+    altformavail: Existence and Location of Copies
+    appraisal: Appraisal
+    arrangement: Arrangement
+    bibliography: Bibliography
+    note_bibliography: Bibliography
+    bioghist: Biographical / Historical
+    custodhist: Custodial History
+    fileplan: File Plan
+    index: Index
+    odd: General
+    otherfindaid: Other Finding Aids
+    originalsloc: Existence and Location of Originals
+    phystech: Physical Characteristics and Technical Requirements
+    prefercite: Preferred Citation
+    processinfo: Processing Information
+    scopecontent: Scope and Contents
+    separatedmaterial: Separated Materials
+    userestrict: Conditions Governing Use
+    dimensions: Dimensions
+    legalstatus: Legal Status
+    summary: Summary
+    edition: Edition
+    extent: Extent
+    note: General Note
+    inscription: Inscription
+    langmaterial: Language of Materials
+    physdesc: Physical Description
+    relatedmaterial: Related Materials
+    abstract: Abstract
+    physloc: Physical Location
+    materialspec: Materials Specific Details
+    physfacet: Physical Facet
+    rights_statement: Rights
+  note_digital_object_type:
+    <<: *note_type_definitions
+  note_langmaterial_type:
+    <<: *note_type_definitions
+  note_multipart_type:
+    <<: *note_type_definitions
+  note_singlepart_type:
+    <<: *note_type_definitions
+  note_rights_statement_type:
+    materials: Materials
+    type_note: Type Note
+    additional_information: Additional Information
+  note_rights_statement_act_type:
+    expiration: Expiration
+    extension: Extension
+    permissions: Permissions
+    restrictions: Restrictions
+    additional_information: Additional Information
+  linked_agent_role:
+    creator: Creator
+    source: Source
+    subject: Subject
+  agent_relationship_associative_relator:
+    is_associative_with: Associative with Related
+  agent_relationship_earlierlater_relator:
+    is_earlier_form_of: Earlier Form of Related
+    is_later_form_of: Later Form of Related
+  agent_relationship_parentchild_relator:
+    is_child_of: Child of Related
+    is_parent_of: Parent of Related
+  accession_sibling_relator:
+    sibling_of: Is Sibling of
+  accession_parts_relator:
+    forms_part_of: Forms Part of
+    has_part: Has Part
+  accession_parts_relator_type:
+    part: "\"Part\" relationship"
+  accession_sibling_relator_type:
+    bound_with: "\"Bound With\" relationship"
+  agent_relationship_subordinatesuperior_relator:
+    is_subordinate_to: Is Subordinate to Related
+    is_superior_of: Is Superior of Related
+  note_index_item_type:
+    name: Name
+    person: Person
+    family: Family
+    corporate_entity: Corporate Entity
+    subject: Subject
+    function: Function
+    occupation: Occupation
+    title: Title
+    genre_form: Genre / Form
+    geographic_name: Geographic Name
+  user_defined_enum_1:
+    novalue: No value defined
+  user_defined_enum_2:
+    novalue: No value defined
+  user_defined_enum_3:
+    novalue: No value defined
+  user_defined_enum_4:
+    novalue: No value defined
+  dimension_units:
+    inches: Inches
+    feet: Feet
+    yards: Yards
+    millimeters: Millimeters
+    centimeters: Centimeters
+    meters: Meters
+  restriction_type:
+    RestrictedSpecColl: 1 - Donor/university imposed access restriction
+    RestrictedCurApprSpecColl: 2 - Repository imposed access restriction
+    RestrictedFragileSpecColl: 3 - Restricted fragile
+    InProcessSpecColl: 4 - Restricted in-process
+    ColdStorageBrbl: 5 - Other
+  location_function_type:
+    av_materials: Audiovisual Materials
+    arrivals: Arrivals
+    shared: Shared
+  rights_statement_external_document_identifier_type:
+    agrovoc: "AGROVOC multilingual agricultural thesaurus. (Rome: APIMONDIA)"
+    allmovie: "AllMovie"
+    allmusic: "AllMusic"
+    allocine: "AlloCiné"
+    amnbo: "American National Biography Online"
+    ansi: "American National Standards Institute and National Information Standards Organisation number for an ANSI or ANSI/NISO standard"
+    artsy: "Artsy"
+    bdusc: "Biographical Directory of the United States Congress (United States Congress)"
+    bfi: "BFI - British Film Institute"
+    bnfcg: "BnF catalogue général (Paris: Bibliothèque nationale de France)"
+    cantic: "CANTIC (Catàleg d'autoritats de noms i títols de Catalunya) (Biblioteca de Catalunya)"
+    cgndb: "Canadian Geographical Names Database (Natural Resources Canada)"
+    danacode: "Danacode (Bnei Brak, Israel: D.A.N.A. Systems)"
+    datoses: "datos.bne.es (Biblioteca Nacional de España)"
+    discogs: "Discogs"
+    dkfilm: "Det Danske Filminstitut Filmdatabasen"
+    doi: "Digital Object Identifier"
+    ean: "International Article Number"
+    eidr: "EIDR: Entertainment Identifier Registry"
+    fast: "Faceted Application of Subject Terminology (Dublin, Ohio: OCLC)"
+    filmport: "filmportal.de"
+    findagr: "Find a Grave"
+    freebase: "Freebase"
+    gec: "Gran enciclopèdia catalana"
+    geogndb: "Geographic Names Database"
+    geonames: "GeoNames"
+    gettytgn: "Getty Thesaurus of Geographic Names Online (J. Paul Getty Trust)"
+    gettyulan: "Union List of Artist Names Online (J. Paul Getty Trust)"
+    gnd: "Gemeinsame Normdatei (Leipzig, Frankfurt: Deutsche Nationalbibliothek)"
+    gnis: "Geographic Names Information System (GNIS) (United States Geological Survey, Board on Geographic Names)"
+    gtin-14: "Global Trade Identification Number 14 (EAN/UCC-128 or ITF-14)"
+    hdl: "Handle"
+    ibdb: "IBDB - Internet Broadway Database"
+    idref: "IdRef: le referentiel des autorites Sudoc (L'agence bibliographique de l'enseignement superieur (ABES))"
+    imdb: "IMDb - Internet Movie Database"
+    isan: "International Standard Audiovisual Number"
+    isbn: "International Standard Book Number"
+    isbn-a: "International Standard Book Number (the actionable ISBN) (International DOI Foundation (IDF))"
+    isbnre: "ISBN (International Standard Book Number) registrant element"
+    isil: "ISIL (International Standard Identifier for Libraries and Related Organizations)"
+    ismn: "International Standard Music Number"
+    isni: "International Standard Name Identifier"
+    iso: "International Organization for Standardization number for an ISO standard"
+    isrc: "International Standard Recording Code"
+    issn: "International Standard Serial Number"
+    issn-l: "Linking International Standard Serial Number"
+    issue-number: "Sound recording issue number"
+    istc: "International Standard Text Code"
+    iswc: "International Standard Musical Work Code"
+    itar: "ITAR (Importtjeneste og autoritetsregistre)"
+    kinopo: "КиноПоиск = KinoPoisk"
+    lccn: "Library of Congress Control Number"
+    lcmd: "Library of Congress Manuscript Division (Washington, DC: Library of Congress)"
+    lcmpt: "Library of Congress Medium of Performance Thesaurus for Music (LCMPT) (Washington, DC: Library of Congress)"
+    libaus: "Libraries Australia (National Library of Australia)"
+    local: "Locally defined identifier"
+    matrix-number: "Sound recording matrix number"
+    moma: "Museum of Modern Art (New York: Museum of Modern Art)"
+    munzing: "Munzinger (Munzinger Archiv)"
+    music-plate: "Publisher's music plate number"
+    music-publisher: "Publisher-assigned music number"
+    musicb: "MusicBrainz"
+    natgazfid: "U.S. National Gazetteer Feature Name Identifier"
+    nga: "National Gallery of Art (Washington DC: National Gallery of Art)"
+    nipo: "Número de Identificación de las Publicaciones Oficiales"
+    nndb: "NNDB (Notable Names Database)"
+    npg: "National Portrait Gallery (London: National Portrait Gallery)"
+    odnb: "Oxford Dictionary of National Biography (Oxford University Press)"
+    opensm: "OpenStreetMap"
+    orcid: "Open Researcher and Contributor IDentifier"
+    oxforddnb: "Oxford Biography Index"
+    porthu: "PORT.hu"
+    rbmsbt: "RBMS Controlled Vocabularies: Binding Terms (Rare Books and Manuscripts Section, Association of College & Research Libraries)"
+    rbmsgt: "RBMS Controlled Vocabularies: Genre Terms (Rare Books and Manuscripts Section, Association of College & Research Libraries)"
+    rbmspe: "RBMS Controlled Vocabularies: Provenance Evidence (Rare Books and Manuscripts Section, Association of College & Research Libraries)"
+    rbmsppe: "RBMS Controlled Vocabularies: Printing and Publishing Evidence (Rare Books and Manuscripts Section, Association of College & Research Libraries)"
+    rbmspt: "RBMS Controlled Vocabularies: Paper Terms (Rare Books and Manuscripts Section Association of College & Research Libraries)"
+    rbmsrd: "RBMS Controlled Vocabularies: Relationship Designators (Rare Books and Manuscripts Section, Association of College & Research Libraries)"
+    rbmste: "RBMS Controlled Vocabularies: Type Evidence (Rare Books and Manuscripts Section, Association of College & Research Libraries)"
+    rid: "ResearcherID (Thomson Reuters)"
+    rkda: "RKDartists& (Den Haag: Rijksbureau voor Kunsthistorische Documentatie)"
+    saam: "Smithsonian American Art Museum (Washington DC: Smithsonian Institution)"
+    scholaru: "Scholar Universe"
+    scope: "Scope"
+    scopus: "Scopus Author Identifier"
+    sici: "Serial Item and Contribution Identifier"
+    spotify: "Spotify"
+    sprfbsb: "Sports Reference: Baseball"
+    sprfbsk: "Sports Reference: Basketball"
+    sprfcbb: "Sports Reference: College Basketball"
+    sprfcfb: "Sports Reference: College Football"
+    sprfhoc: "Sports Reference: Hockey"
+    sprfoly: "Sports Reference: Olympic Sports"
+    sprfpfb: "Sports Reference: Pro Football"
+    stock-number: "Publisher, distributor, or vendor stock number"
+    strn: "Standard Technical Report Number"
+    svfilm: "Svensk Filmdatabas"
+    tatearid: "Tate Artist Identifier"
+    theatr: "Theatricalia"
+    trove: "Trove (National Library of Australia)"
+    upc: "Universal Product Code"
+    uri: "Uniform Resource Identifier"
+    urn: "Uniform Resource Name"
+    viaf: "Virtual International Authority File number"
+    videorecording-identifier: "Publisher-assigned videorecording number"
+    wikidata: "Wikidata (Wikimedia Foundation)"
+    wndla: "Web NDL Authorities (Tokyo: National Diet Library (NDL))"
+
+enumeration_names:
+  accession_acquisition_type: Accession Acquisition Type
+  accession_parts_relator: Accession Parts Relator
+  accession_parts_relator_type: Accession Parts Relator Type
+  accession_sibling_relator: "Accession Sibling Relator"
+  accession_sibling_relator_type: Accession Sibling Relator Type
+  accession_resource_type: Accession Resource Type
+  agent_contact_salutation: Agent Contact Salutation
+  agent_relationship_associative_relator: Agent Relationship Associative Relator
+  agent_relationship_earlierlater_relator: Agent Relationship Earlierlater Relator
+  agent_relationship_parentchild_relator: Agent Relationship Parentchild Relator
+  agent_relationship_subordinatesuperior_relator: Agent Relationship Subordinatesuperior Relator
+  archival_record_level: Archival Record Level
+  collection_management_processing_priority: Collection Management Processing Priority
+  collection_management_processing_status: Collection Management Processing Status
+  container_location_status: Container Location Status
+  container_type: Container Type
+  country_iso_3166: Country ISO 3166
+  date_calendar: Date Calendar
+  date_certainty: Date Certainty
+  date_era: Date Era
+  date_label: Date Label
+  date_type: Date Type
+  deaccession_scope: Deaccession Scope
+  digital_object_digital_object_type: Digital Object Digital Object Type
+  digital_object_level: Digital Object Level
+  event_event_type: Event Event Type
+  event_outcome: Event Outcome
+  extent_extent_type: Extent Extent Type
+  extent_portion: Extent Portion
+  file_version_checksum_methods: File Version Checksum Methods
+  file_version_file_format_name: File Version File Format Name
+  file_version_use_statement: File Version Use Statement
+  file_version_xlink_actuate_attribute: File Version Xlink Actuate Attribute
+  file_version_xlink_show_attribute: File Version Xlink Show Attribute
+  instance_instance_type: Instance Instance Type
+  language_iso639_2: Language ISO 639-2
+  script_iso15924: Language Script ISO 15924
+  linked_agent_archival_record_relators: Linked Agent Archival Record Relators
+  linked_agent_event_roles: Linked Agent Event Roles
+  linked_agent_role: Linked Agent Role
+  linked_event_archival_record_roles: Linked Event Archival Record Roles
+  location_temporary: Location Temporary
+  name_person_name_order: Name Person Name Order
+  name_rule: Name Rule
+  name_source: Name Source
+  note_bibliography_type: Note Bibliography Type
+  note_digital_object_type: Note Digital Object Type
+  note_langmaterial_type: Note Language of Materials Type
+  note_index_item_type: Note Index Item Type
+  note_index_type: Note Index Type
+  note_multipart_type: Note Multipart Type
+  note_orderedlist_enumeration: Note Orderedlist Enumeration
+  note_rights_statement_act_type: Note Rights Statement Act Type
+  note_rights_statement_type: Note Rights Statement Type
+  note_singlepart_type: Note Singlepart Type
+  telephone_number_type: Telephone Number Type
+  resource_finding_aid_description_rules: Resource Finding Aid Description Rules
+  resource_finding_aid_status: Resource Finding Aid Status
+  resource_resource_type: Resource Resource Type
+  rights_statement_ip_status: Rights Statement IP Status
+  rights_statement_rights_type: Rights Statement Rights Type
+  subject_source: Subject Source
+  subject_term_type: Subject Term Type
+  user_defined_enum_1: User Defined Enum 1
+  user_defined_enum_2: User Defined Enum 2
+  user_defined_enum_3: User Defined Enum 3
+  user_defined_enum_4: User Defined Enum 4
+  job_type: Job Type
+  dimension_units: Dimension Units
+  restriction_type: Local Access Restriction Type
+  location_function_type: Location Function Type
+  rights_statement_external_document_identifier_type: Rights Statement External Document Identifier Type
+  rights_statement_act_restriction: Rights Statement Act Restriction
+  rights_statement_act_type: Rights Statement Act Type
+  rights_statement_other_rights_basis: Rights Statement Other Rights Basis

--- a/go.mod
+++ b/go.mod
@@ -19,4 +19,5 @@ require (
 	github.com/urfave/cli v1.22.1
 	golang.org/x/net v0.0.0-20191112182307-2180aed22343 // indirect
 	golang.org/x/text v0.3.2 // indirect
+	gopkg.in/yaml.v2 v2.2.8
 )

--- a/go.sum
+++ b/go.sum
@@ -68,3 +68,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
#### What does this PR do?

Makes a few changes to the archives parser and related tests. Fields update include ContentType (added to ES record), Links (updated the link "kind"), and Contributor (added the roles lookup and a better fallback).

#### How can a reviewer manually see the effects of these changes?

Ingest some Aspace records and view the result. You should now see a ContentType in the full record, any links types should be Kind: Digital object, and the Contributor default for most records will be Creator (reflecting the Aspace record default).

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DIP-261

#### Requires Full Reindexing of all Sources?
Aspace only

#### Includes new or updated dependencies?
YES
