### PR TITLE
Remove colons from index name

### DIFF
--- a/main.go
+++ b/main.go
@@ -126,7 +126,7 @@ func main() {
 
 				if index == "" {
 					t := time.Now().UTC()
-					ft := strings.ToLower(t.Format(time.RFC3339))
+					ft := t.Format("2006-01-02t15-04-05z")
 					index = fmt.Sprintf("%s-%s", c.String("prefix"), ft)
 				}
 


### PR DESCRIPTION
This fixes #85. The colons are just replaced with dashes in the datetime
appended to the index name. The change shouldn't affect anything with
the current pipeline.

#### How can a reviewer manually see the effects of these changes?

1. Startup a local ES instance
2. `make install`
3. `mario ingest --auto fixtures/mit_test_records.mrc`
4. `mario aliases`

#### Requires Full Reindexing of all Sources?
YES

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
