### PR TITLE
Add a reindex command

### DIFF
--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -172,3 +172,13 @@ func after(exID int64, requests []elastic.BulkableRequest, resp *elastic.BulkRes
 		}
 	}
 }
+
+func reindex(client *elastic.Client, source string, destination string) error {
+	ctx := context.Background()
+	resp, err := client.Reindex().SourceIndex(source).DestinationIndex(destination).Do(ctx)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Reindexed %d docs from %s into %s\n", resp.Total, source, destination)
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -298,6 +298,26 @@ func main() {
 				return nil
 			},
 		},
+		{
+			Name:      "reindex",
+			Usage:     "Reindex one index to another index.",
+			UsageText: "Use the Elasticsearch reindex API to copy one index to another. The doc source must be present in the original index.",
+			Category:  "Index actions",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "destination",
+					Usage: "Name of new index",
+				},
+			},
+			Action: func(c *cli.Context) error {
+				client, err := esClient(url, index, v4)
+				if err != nil {
+					return err
+				}
+				reindex(client, index, c.String("destination"))
+				return nil
+			},
+		},
 	}
 
 	err := app.Run(os.Args)


### PR DESCRIPTION
The reindex command wouldn't be used for the normal ingest process,
but it's useful to have around when an existing index needs to be
reindexed for some reason. This is much faster than reindexing from
source.

#### How can a reviewer manually see the effects of these changes?

1. Start up an ES instance
2. mario --index foo ingest fixtures/mit_test_records.mrc
3. mario --index foo reindex --destination bar

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
