### PR TITLE
Add new CLI and new bucket ADRs

### DIFF
--- a/docs/architecture-decisions/0008-use-one-s3-bucket-per-source.md
+++ b/docs/architecture-decisions/0008-use-one-s3-bucket-per-source.md
@@ -4,7 +4,7 @@ Date: 2018-07-05
 
 ## Status
 
-Accepted
+Superceded by [15. Use a Single Bucket](0015-use-a-single-bucket.md)
 
 ## Context
 

--- a/docs/architecture-decisions/0011-indexing-commands-and-flows.md
+++ b/docs/architecture-decisions/0011-indexing-commands-and-flows.md
@@ -4,7 +4,7 @@ Date: 2018-11-26
 
 ## Status
 
-Accepted
+Superceded by [14. Structure of CLI](0014-structure-of-cli.md)
 
 ## Context
 

--- a/docs/architecture-decisions/0014-structure-of-cli.md
+++ b/docs/architecture-decisions/0014-structure-of-cli.md
@@ -1,0 +1,30 @@
+# 14. Structure of CLI
+
+Date: 2020-04-08
+
+## Status
+
+Accepted
+
+Supercedes [11. Indexing Commands and Flows](0011-indexing-commands-and-flows.md)
+
+## Context
+
+Our current command line interface is awkward to use and contains a considerable amount of business logic. Rather than listing out every command, this ADR will provide guidelines for adding new commands.
+
+## Decision
+
+The mario command itself will be a collection of subcommands. Only use global options for values that can truly be applied for every subcommand. All other options should be attached to the subcommand. Provide reasonable default values when it makes sense.
+
+A few examples:
+
+```
+$ mario ingest --v4 --index aleph-2020-01-01 s3://bucket/key.mrc
+$ mario reindex --url http://example.com -s aleph-01 -d aleph-02
+```
+
+Additionally, the `main.go` file should be kept small and all business logic should reside elsewhere in the application.
+
+## Consequences
+
+The `main.go` file will need a significant rewrite in order to pull out the business logic which is currently in there. The CLI will also likely change (`--index` is currently a global option, which makes no sense for most subcommands). Changes to the CLI will need to be propagated to the automated ingest workflow processes.

--- a/docs/architecture-decisions/0015-use-a-single-bucket.md
+++ b/docs/architecture-decisions/0015-use-a-single-bucket.md
@@ -1,0 +1,29 @@
+# 15. Use a Single Bucket
+
+Date: 2020-04-08
+
+## Status
+
+Accepted
+
+Supercedes [8. Use One S3 Bucket Per Source](0008-use-one-s3-bucket-per-source.md)
+
+## Context
+
+There are a couple reasons to switch from multiple buckets to a single bucket. The first is that it simplifies the infrastructure provisioning that needs to be done when a new source is added. The second is that there is a hard limit on the number of buckets an AWS account can have, and our current approach to bucket creation is unsustainable.
+
+## Decision
+
+Use a single namespaced S3 bucket for all source data. The structure of the bucket should be:
+
+```
+s3://bucket/<environment>/<source>/<files>
+```
+
+Where `environment` would be either `prod` or `stage`, and `source` would be the source identifier. The source identifier used here should also be used as the prefix for the index name. No specific decisions are made here about how the files are structured within a source.
+
+mario should ignore source identifiers that it does not know about.
+
+## Consequences
+
+Changes will be needed both in mario and in the scripts that upload data to the current bucket.

--- a/docs/architecture-decisions/0015-use-a-single-bucket.md
+++ b/docs/architecture-decisions/0015-use-a-single-bucket.md
@@ -26,4 +26,4 @@ mario should ignore source identifiers that it does not know about.
 
 ## Consequences
 
-Changes will be needed both in mario and in the scripts that upload data to the current bucket.
+Changes will be needed both in mario and in the scripts that upload data to the current bucket. It's worth noting that bucket policies around lifecycle and permissions can be applied to objects based on prefix, so any existing needs specific to a source can be supported with this change.


### PR DESCRIPTION
This proposes to replace a couple ADRs. The first defines the structure
of the CLI, but more in terms of guidelines than explicitly listing out
commands. As the CLI will likely continue to evolve, this ADR should
remain relevant with those changes.

The second ADR redefines our usage of S3 buckets, shifting to a single
bucket for all source data.
