### PR TITLE
Add a new Elasticsearch client

### DIFF
--- a/pkg/client/elastic.go
+++ b/pkg/client/elastic.go
@@ -1,0 +1,159 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/mitlibraries/mario/pkg/record"
+	"github.com/olivere/elastic"
+	aws "github.com/olivere/elastic/aws/v4"
+	"io/ioutil"
+	"net/http"
+)
+
+// Primary alias
+const primary = "timdex-prod"
+
+// ESClient wraps an olivere/elastic client. Create a new client with the
+// NewESClient function.
+type ESClient struct {
+	client *elastic.Client
+	bulker *elastic.BulkProcessor
+}
+
+// Current returns the name of the current index for the given prefix. A
+// current index is defined as one which is linked to the primary alias. An
+// error is returned if there is more than one matching index. An empty
+// string indicates there were no matching indexes.
+func (c ESClient) Current(prefix string) (string, error) {
+	res, err := c.client.Aliases().Index(prefix + "*").Do(context.Background())
+	if err != nil {
+		return "", err
+	}
+	aliases := res.IndicesByAlias(primary)
+	if len(aliases) == 0 {
+		return "", nil
+	} else if len(aliases) > 0 {
+		return "", errors.New("Could not determine current index")
+	} else {
+		return aliases[0], nil
+	}
+}
+
+// Create the new index.
+func (c ESClient) Create(index string) error {
+	mappings, err := ioutil.ReadFile("config/es_record_mappings.json")
+	if err != nil {
+		return err
+	}
+	_, err = c.client.
+		CreateIndex(index).
+		BodyString(string(mappings)).
+		Do(context.Background())
+	return err
+}
+
+// Start the bulk processor.
+func (c *ESClient) Start() error {
+	bulker, err := c.client.
+		BulkProcessor().
+		Name("BulkProcessor").
+		Workers(2).
+		Do(context.Background())
+	c.bulker = bulker
+	return err
+}
+
+// Stop the bulk processor.
+func (c *ESClient) Stop() error {
+	return c.bulker.Stop()
+}
+
+// Add a record using a bulk processor.
+func (c *ESClient) Add(record record.Record, index string) {
+	d := elastic.NewBulkIndexRequest().
+		Index(index).
+		Id(record.Identifier).
+		Doc(record)
+	c.bulker.Add(d)
+}
+
+// Promote will add the given index to the primary alias. If there is an
+// existing index matching the prefix linked to the primary alias it will
+// be removed from the alias. This action is atomic.
+func (c ESClient) Promote(index string, prefix string) error {
+	svc := c.client.Alias().Add(index, primary)
+	current, err := c.Current(prefix)
+	if err != nil {
+		return err
+	}
+	if current != "" {
+		svc.Remove(current, primary)
+	}
+	_, err = svc.Do(context.Background())
+	return err
+}
+
+// Delete an index.
+func (c ESClient) Delete(index string) error {
+	_, err := c.client.DeleteIndex(index).Do(context.Background())
+	return err
+}
+
+func (c ESClient) Indexes() (elastic.CatIndicesResponse, error) {
+	return c.client.
+		CatIndices().
+		Columns("idx", "dc", "h", "s", "id", "ss").
+		Do(context.Background())
+}
+
+func (c ESClient) Aliases() (elastic.CatAliasesResponse, error) {
+	return c.client.CatAliases().Do(context.Background())
+}
+
+func (c ESClient) Ping(url string) (*elastic.PingResult, error) {
+	res, _, err := c.client.Ping(url).Do(context.Background())
+	return res, err
+}
+
+// Reindex the source index to the destination index. Returns the number
+// of documents reindexed.
+func (c ESClient) Reindex(source string, dest string) (int64, error) {
+	resp, err := c.client.
+		Reindex().
+		SourceIndex(source).
+		DestinationIndex(dest).
+		Do(context.Background())
+	if err != nil {
+		return 0, err
+	}
+	return resp.Total, nil
+}
+
+// NewESClient creates a new Elasticsearch client.
+func NewESClient(url string, v4 bool) (ESClient, error) {
+	var client *http.Client
+	if v4 {
+		sess := session.Must(session.NewSession())
+		creds := credentials.NewChainCredentials([]credentials.Provider{
+			&credentials.EnvProvider{},
+			&credentials.SharedCredentialsProvider{},
+			&ec2rolecreds.EC2RoleProvider{
+				Client: ec2metadata.New(sess),
+			},
+		})
+		client = aws.NewV4SigningClient(creds, "us-east-1")
+	} else {
+		client = http.DefaultClient
+	}
+	es, err := elastic.NewClient(
+		elastic.SetURL(url),
+		elastic.SetSniff(false),
+		elastic.SetHealthcheck(false),
+		elastic.SetHttpClient(client),
+	)
+	return ESClient{client: es}, err
+}

--- a/pkg/record/record.go
+++ b/pkg/record/record.go
@@ -1,0 +1,97 @@
+package record
+
+// Record struct stores our internal mappings of data and is used to when
+// mapping various external data sources before sending to elasticsearch
+type Record struct {
+	Identifier           string         `json:"identifier"`
+	Source               string         `json:"source"`
+	SourceLink           string         `json:"source_link"`
+	Title                string         `json:"title"`
+	AlternateTitles      []string       `json:"alternate_titles,omitempty"`
+	Contributor          []*Contributor `json:"contributors,omitempty"`
+	Subject              []string       `json:"subjects,omitempty"`
+	Isbn                 []string       `json:"isbns,omitempty"`
+	Issn                 []string       `json:"issns,omitempty"`
+	Doi                  []string       `json:"dois,omitempty"`
+	OclcNumber           []string       `json:"oclcs,omitempty"`
+	Lccn                 string         `json:"lccn,omitempty"`
+	Country              string         `json:"place_of_publication,omitempty"`
+	Language             []string       `json:"languages,omitempty"`
+	PublicationDate      string         `json:"publication_date,omitempty"`
+	ContentType          string         `json:"content_type,omitempty"`
+	CallNumber           []string       `json:"call_numbers,omitempty"`
+	Edition              string         `json:"edition,omitempty"`
+	Imprint              []string       `json:"imprint,omitempty"`
+	PhysicalDescription  string         `json:"physical_description,omitempty"`
+	PublicationFrequency []string       `json:"publication_frequency,omitempty"`
+	Numbering            string         `json:"numbering,omitempty"`
+	Notes                []string       `json:"notes,omitempty"`
+	Contents             []string       `json:"contents,omitempty"`
+	Summary              []string       `json:"summary,omitempty"`
+	Format               []string       `json:"format,omitempty"`
+	LiteraryForm         string         `json:"literary_form,omitempty"`
+	RelatedPlace         []string       `json:"related_place,omitempty"`
+	InBibliography       []string       `json:"in_bibliography,omitempty"`
+	RelatedItems         []*RelatedItem `json:"related_items,omitempty"`
+	Links                []Link         `json:"links,omitempty"`
+	Holdings             []Holding      `json:"holdings,omitempty"`
+	Citation             string         `json:"citation,omitempty"`
+}
+
+// Contributor is a port of a Record
+type Contributor struct {
+	Kind  string `json:"kind"`
+	Value string `json:"value"`
+}
+
+// RelatedItem is a port of a Record
+type RelatedItem struct {
+	Kind  string   `json:"kind"`
+	Value []string `json:"value"`
+}
+
+// Link is a port of a Record
+type Link struct {
+	Kind         string `json:"kind,omitempty"`
+	Text         string `json:"text,omitempty"`
+	URL          string `json:"url"`
+	Restrictions string `json:"restrictions,omitempty"`
+}
+
+// Holding is a port of a Record
+type Holding struct {
+	Location   string `json:"location"`
+	Collection string `json:"collection,omitempty"`
+	CallNumber string `json:"call_number,omitempty"`
+	Summary    string `json:"summary,omitempty"`
+	Notes      string `json:"notes,omitempty"`
+	Format     string `json:"format,omitempty"`
+}
+
+// Rule defines where the rules are in JSON
+type Rule struct {
+	Label  string   `json:"label"`
+	Array  bool     `json:"array"`
+	Fields []*Field `json:"fields"`
+}
+
+// Field defines where the Fields within a Rule are in JSON
+type Field struct {
+	Tag       string `json:"tag"`
+	Subfields string `json:"subfields"`
+	Bytes     string `json:"bytes"`
+	Kind      string `json:"kind"`
+}
+
+// Parser defines an interface common to parsers
+type Parser interface {
+	Parse(chan Record)
+}
+
+// Processor is an interface that allows converting from custom data into
+// our Record structure
+type Processor interface {
+	Process()
+}
+
+var ingested int


### PR DESCRIPTION
This adds a new client that wraps the underlying Elasticsearch client.
The goal here is to address two existing problems. The first is that a
lot of business logic has found its way into main.go and it needs to not
live there. This moves most of the logic around indexes into this
client. The second problem is that the direct usage of the underlying
client makes it difficult to unit test parts of the application. By
encapsulating that in a trimmed down client we can more easily mock an
Elasticsearch instance.

The client also more explicitly enforces business rules for our indexing
strategy. Retrieving the current index for a particular source will
return an error if more than one index is found. Promoting a new index
is now an atomic action. These steps should prevent us from reaching a
state where the primary alias points to more than index from one source.

It's worth noting that this simply adds the client. The rest of the app
will need to be updated to use it.

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
