### PR TITLE
Fix broken docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,12 @@ COPY pkg pkg
 COPY cmd cmd
 COPY config config
 RUN \
-  pkger -include /config && \
+  pkger && \
   go build -o mario cmd/mario/main.go
 
-FROM alpine
+FROM golang:1.13-alpine
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=0 /go/src/mario/mario .
+COPY --from=0 /go/src/mario/config ./config
 ENTRYPOINT ["./mario"]
 CMD ["--help"]


### PR DESCRIPTION
There were a few things wrong with the docker image as a result of
switching to pkger. The first is that it apparently needs underlying go
tooling on the system, so the base build for the production container
was switched to the golang alpine image. The second is mostly that I
still don't really understand how pkger works. I think the problem is
probably due to the interactions between pkger and go modules. More work
to understand what's going on here is needed, but for now copying the
config files to the final layer is a quick fix.

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
