### PR TITLE
Replace logging that was removed

### DIFF
--- a/cmd/mario/main.go
+++ b/cmd/mario/main.go
@@ -10,7 +10,6 @@ import (
 )
 
 func main() {
-	var debug bool
 	var auto bool
 	var url, index string
 	var v4 bool
@@ -64,11 +63,6 @@ func main() {
 					Usage: "Index prefix to use: default is aleph",
 				},
 				cli.BoolFlag{
-					Name:        "debug",
-					Usage:       "Output debugging information",
-					Destination: &debug,
-				},
-				cli.BoolFlag{
 					Name:        "auto",
 					Usage:       "Automatically promote / demote on completion",
 					Destination: &auto,
@@ -85,9 +79,7 @@ func main() {
 					Promote:   auto,
 					Rulesfile: c.String("rules"),
 				}
-				if debug {
-					log.Printf("Ingesting records from file: %s\n", config.Filename)
-				}
+				log.Printf("Ingesting records from file: %s\n", config.Filename)
 				stream, err := ingester.NewStream(config.Filename)
 				if err != nil {
 					return err
@@ -101,14 +93,12 @@ func main() {
 				}
 
 				ingest := ingester.Ingester{Stream: stream, Client: es}
-				err = ingest.Configure(config, debug)
+				err = ingest.Configure(config)
 				if err != nil {
 					return err
 				}
 				count, err := ingest.Ingest()
-				if debug {
-					log.Printf("Total records ingested: %d\n", count)
-				}
+				log.Printf("Total records ingested: %d\n", count)
 				return err
 			},
 		},

--- a/cmd/mario/main.go
+++ b/cmd/mario/main.go
@@ -104,7 +104,7 @@ func main() {
 				}
 				count, err := ingest.Ingest()
 				if debug {
-					fmt.Printf("Total records ingested: %d\n", count)
+					log.Printf("Total records ingested: %d\n", count)
 				}
 				return err
 			},

--- a/cmd/mario/main.go
+++ b/cmd/mario/main.go
@@ -85,6 +85,9 @@ func main() {
 					Promote:   auto,
 					Rulesfile: c.String("rules"),
 				}
+				if debug {
+					log.Printf("Ingesting records from file: %s\n", config.Filename)
+				}
 				stream, err := ingester.NewStream(config.Filename)
 				if err != nil {
 					return err
@@ -98,7 +101,7 @@ func main() {
 				}
 
 				ingest := ingester.Ingester{Stream: stream, Client: es}
-				err = ingest.Configure(config)
+				err = ingest.Configure(config, debug)
 				if err != nil {
 					return err
 				}

--- a/pkg/generator/marc.go
+++ b/pkg/generator/marc.go
@@ -74,14 +74,15 @@ func (m *MarcGenerator) Generate() <-chan record.Record {
 
 func (m *marcparser) parse(out chan record.Record) {
 	mr := fml.NewMarcIterator(m.file)
+	var totalRecordCount int
 	var errorCount int
 
 	for mr.Next() {
 		record, err := mr.Value()
+		totalRecordCount++
 
 		if err != nil {
-			log.Println("Error parsing MARC record:", record.ControlNum())
-			log.Println(err)
+			log.Printf("Error parsing MARC record: %s, %s", record.ControlNum(), err)
 			// os.Stderr.WriteString("--- Begin Problem MARC Record ---\n")
 			// os.Stderr.Write(record.Data)
 			// os.Stderr.WriteString("\n--- End Problem MARC Record ---\n")
@@ -98,6 +99,7 @@ func (m *marcparser) parse(out chan record.Record) {
 		}
 	}
 
+	log.Printf("Total records processed: %d", totalRecordCount)
 	log.Printf("Error records: %s", strconv.Itoa(errorCount))
 	close(out)
 }

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -53,7 +53,7 @@ type Ingester struct {
 }
 
 // Configure an Ingester. This should be called before Ingest.
-func (i *Ingester) Configure(config Config) error {
+func (i *Ingester) Configure(config Config, debug bool) error {
 	var err error
 	// Configure generator
 	if config.Source == "json" {
@@ -80,12 +80,16 @@ func (i *Ingester) Configure(config Config) error {
 
 		if config.Index == "" {
 			if strings.Contains(config.Filename, "mit01_edsu1") {
-				log.Printf("Update file detected: %s", config.Filename)
+				if debug {
+					log.Printf("Update file detected: %s", config.Filename)
+				}
 				current, err := i.Client.Current(config.Prefix)
 				if err != nil || current == "" {
 					return errors.New("Could not determine current index to update")
 				}
-				log.Printf("Using existing index: %s", current)
+				if debug {
+					log.Printf("Using existing index: %s", current)
+				}
 				config.Index = current
 				config.Promote = false
 			} else {
@@ -104,7 +108,10 @@ func (i *Ingester) Configure(config Config) error {
 			Client: i.Client,
 		}
 
-		log.Printf("Configured Elasticsearch consumer with index: %s, prefix: %s, and promote: %s", config.Index, config.Prefix, strconv.FormatBool(config.Promote))
+		if debug {
+			log.Printf("Configured Elasticsearch consumer with index: %s, prefix: %s, and promote: %s", config.Index, config.Prefix, strconv.FormatBool(config.Promote))
+		}
+
 
 	} else if config.Consumer == "json" {
 		i.consumer = &consumer.JSONConsumer{Out: os.Stdout}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -53,7 +53,7 @@ type Ingester struct {
 }
 
 // Configure an Ingester. This should be called before Ingest.
-func (i *Ingester) Configure(config Config, debug bool) error {
+func (i *Ingester) Configure(config Config) error {
 	var err error
 	// Configure generator
 	if config.Source == "json" {
@@ -80,16 +80,12 @@ func (i *Ingester) Configure(config Config, debug bool) error {
 
 		if config.Index == "" {
 			if strings.Contains(config.Filename, "mit01_edsu1") {
-				if debug {
-					log.Printf("Update file detected: %s", config.Filename)
-				}
+				log.Printf("Update file detected: %s", config.Filename)
 				current, err := i.Client.Current(config.Prefix)
 				if err != nil || current == "" {
 					return errors.New("Could not determine current index to update")
 				}
-				if debug {
-					log.Printf("Using existing index: %s", current)
-				}
+				log.Printf("Using existing index: %s", current)
 				config.Index = current
 				config.Promote = false
 			} else {
@@ -108,9 +104,7 @@ func (i *Ingester) Configure(config Config, debug bool) error {
 			Client: i.Client,
 		}
 
-		if debug {
-			log.Printf("Configured Elasticsearch consumer with index: %s, prefix: %s, and promote: %s", config.Index, config.Prefix, strconv.FormatBool(config.Promote))
-		}
+		log.Printf("Configured Elasticsearch consumer with index: %s, prefix: %s, and promote: %s", config.Index, config.Prefix, strconv.FormatBool(config.Promote))
 
 
 	} else if config.Consumer == "json" {


### PR DESCRIPTION
#### What does this PR do?

Adds back the logging that was removed during the application refactor last summer plus a bit of extra logging for debugging. This does not address any other issues around the refactor.

#### Helpful background context

The refactor removed a few lines of logging that are valuable for checking whether Aleph updates are indexing properly. This returns them to the codebase and adds a bit of extra logging to help with debugging.

#### How can a reviewer manually see the effects of these changes?

Run and promote a full Aleph ingest locally, then ingest an update file and see more information in the logging.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DISCO-204
- https://mitlibraries.atlassian.net/browse/DISCO-131
- https://mitlibraries.atlassian.net/browse/DISCO-114

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO

#### Todo:
- [x] Tests
- [x] Documentation
- [x] Stakeholder approval
