### PR TITLE
Simplify use of source/type and prefix in cli

### DIFF
--- a/cmd/mario/main.go
+++ b/cmd/mario/main.go
@@ -59,8 +59,8 @@ func main() {
 				},
 				cli.StringFlag{
 					Name:  "prefix, p",
-					Value: "aleph",
-					Usage: "Index prefix to use: default is aleph",
+					Usage: "Index prefix to use: current options are aleph, aspace, dspace",
+					Required: true,
 				},
 				cli.BoolFlag{
 					Name:        "auto",
@@ -189,8 +189,8 @@ Lucene version: %s
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "prefix, p",
-					Value: "aleph",
-					Usage: "Index prefix to use: default is aleph",
+					Usage: "Index prefix to use: current options are aleph, aspace, dspace",
+					Required: true,
 				},
 			},
 			Action: func(c *cli.Context) error {

--- a/cmd/mario/main.go
+++ b/cmd/mario/main.go
@@ -50,16 +50,11 @@ func main() {
 				cli.StringFlag{
 					Name:  "consumer, c",
 					Value: "es",
-					Usage: "Consumer to use (es, json or title)",
+					Usage: "Consumer to use. Must be one of [es, json, title, silent]",
 				},
 				cli.StringFlag{
-					Name:  "type, t",
-					Value: "marc",
-					Usage: "Type of file to process",
-				},
-				cli.StringFlag{
-					Name:  "prefix, p",
-					Usage: "Index prefix to use: current options are aleph, aspace, dspace",
+					Name:  "source, s",
+					Usage: "Source system of metadata file to process. Must be one of [aleph, aspace, dspace, mario]",
 					Required: true,
 				},
 				cli.BoolFlag{
@@ -73,9 +68,8 @@ func main() {
 				config := ingester.Config{
 					Filename:  c.Args().Get(0),
 					Consumer:  c.String("consumer"),
-					Source:    c.String("type"),
+					Source:    c.String("source"),
 					Index:     index,
-					Prefix:    c.String("prefix"),
 					Promote:   auto,
 					Rulesfile: c.String("rules"),
 				}

--- a/pkg/client/elastic.go
+++ b/pkg/client/elastic.go
@@ -37,12 +37,12 @@ type ESClient struct {
 	bulker *elastic.BulkProcessor
 }
 
-// Current returns the name of the current index for the given prefix. A
+// Current returns the name of the current index for the given source. A
 // current index is defined as one which is linked to the primary alias. An
 // error is returned if there is more than one matching index. An empty
 // string indicates there were no matching indexes.
-func (c ESClient) Current(prefix string) (string, error) {
-	res, err := c.client.Aliases().Index(prefix + "*").Do(context.Background())
+func (c ESClient) Current(source string) (string, error) {
+	res, err := c.client.Aliases().Index(source + "*").Do(context.Background())
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
#### What does this PR do?

Consolidates the `type` and `prefix` flags in the cli into one flag, `source`, which is used to determine both the source data mapping to use and the index name prefix. Also makes `source` a required flag because we don't want to default to a source that may differ from the metadata file being ingested.

#### How can a reviewer manually see the effects of these changes?

`mario ingest -h` will show the cli options. Attempting to run `mario ingest` without a `--source` flag will not work. To see it in action, run `mario ingest -s aleph fixtures/test.mrc`, or corollary command for other sources/source files.

NOTE: It is definitely possible to run this with mismatched source and ingest file. This will either result in no records being ingested or will throw an error, because the parser is determined by the source and will not succeed with a different type of metadata file. However, we should consider also doing an explicit sanity check here and providing useful info to the user about what happened.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DISCO-198
- https://mitlibraries.atlassian.net/browse/DISCO-260

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
