### PR TITLE
Clean up CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,17 @@ as well, use docker-compose to run both docker and TIMDEX locally using the
 instructions in the [TIMDEX README](https://github.com/MITLibraries/timdex/blob/master/README.md#docker-compose-orchestrated-local-environment).
 
 Here are a few sample Mario commands that may be useful for local development:
-- `mario ingest -c json -t archives -p aspace fixtures/aspace_samples.xml`
+- `mario ingest -c json -s aspace fixtures/aspace_samples.xml`
   runs the ingest process with ASpace sample files and prints out each record
   as JSON
-- `mario ingest -t dspace -p dspace fixtures/dspace_samples.xml` ingests the
+- `mario ingest -s dspace fixtures/dspace_samples.xml` ingests the
   DSpace sample files into a local Elasticsearch instance.
-- `mario ingest --auto fixtures/mit_test_records.mrc` ingests the Aleph sample
-  files into a local Elasticsearch instance and promotes the index to the
-  timdex-prod alias on completion.
+- `mario ingest -s aleph --auto fixtures/mit_test_records.mrc` ingests the
+  Aleph sample files into a local Elasticsearch instance and promotes the
+  index to the timdex-prod alias on completion.
 - `mario indexes` list all indexes
-- `mario -i [index name] promote` promotes the named index to the timdex-prod
-  alias.
+- `mario promote -i [index name]` promotes the named index to the
+  timdex-prod alias.
 
 ## Developing
 

--- a/cmd/mario/main.go
+++ b/cmd/mario/main.go
@@ -91,15 +91,10 @@ func main() {
     // Index-specific commands
 		{
 			Name:      "ingest",
-			Usage:     "Parse and ingest the input file to a new or existing index",
+			Usage:     "Parse and ingest the input file. By default, ingests into the current production index for the provided source.",
 			ArgsUsage: "[filepath, use format 's3://bucketname/objectname' for s3]",
       Category:  "Index actions",
 			Flags:     []cli.Flag{
-    		&cli.StringFlag{
-      		Name:    "index",
-    			Aliases: []string{"i"},
-    			Usage:   "Name of the Elasticsearch index to ingest to. If not included, will default to a new index named with the source prefix plus timestamp (except for Aleph update files, which are always ingested into the current production Aleph index)",
-    		},
 				&cli.StringFlag{
 					Name:  	  "source",
 					Aliases:  []string{"s"},
@@ -112,6 +107,10 @@ func main() {
 					Value: 	 "es",
 					Usage: 	 "Consumer to use. Must be one of [es, json, title, silent]",
 				},
+        &cli.BoolFlag{
+          Name: "new",
+          Usage: "Create a new index instead of ingesting into the current production index for the source",
+        },
 				&cli.BoolFlag{
 					Name:  "auto",
 					Usage: "Automatically promote / demote on completion",
@@ -123,7 +122,7 @@ func main() {
 					Filename:  c.Args().Get(0),
 					Consumer:  c.String("consumer"),
 					Source:    c.String("source"),
-					Index:     c.String("index"),
+          NewIndex:  c.Bool("new"),
 					Promote:   c.Bool("auto"),
 				}
 				log.Printf("Ingesting records from file: %s\n", config.Filename)

--- a/cmd/mario/main.go
+++ b/cmd/mario/main.go
@@ -19,7 +19,7 @@ func main() {
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
 			Name:        "url",
-			Aliases: 		 []string{"u"},
+			Aliases:     []string{"u"},
 			Value:       "http://127.0.0.1:9200",
 			Usage:       "URL for the Elasticsearch cluster",
 			Destination: &url,
@@ -32,12 +32,12 @@ func main() {
 	}
 
 	app.Commands = []*cli.Command{
-    // Elasticsearch commands
+		// Elasticsearch commands
 		{
 			Name:     "aliases",
 			Usage:    "List Elasticsearch aliases and their associated indexes",
-      Category: "Elasticsearch actions",
-			Action:   func(c *cli.Context) error {
+			Category: "Elasticsearch actions",
+			Action: func(c *cli.Context) error {
 				es, err := client.NewESClient(url, v4)
 				if err != nil {
 					return err
@@ -52,11 +52,11 @@ func main() {
 				return nil
 			},
 		},
-    {
+		{
 			Name:     "indexes",
 			Usage:    "List all Elasticsearch indexes",
-      Category: "Elasticsearch actions",
-			Action:   func(c *cli.Context) error {
+			Category: "Elasticsearch actions",
+			Action: func(c *cli.Context) error {
 				es, err := client.NewESClient(url, v4)
 				if err != nil {
 					return err
@@ -70,11 +70,11 @@ func main() {
 				}
 				return nil
 			},
-    },
+		},
 		{
 			Name:     "ping",
 			Usage:    "Ping Elasticsearch",
-      Category: "Elasticsearch actions",
+			Category: "Elasticsearch actions",
 			Action: func(c *cli.Context) error {
 				es, err := client.NewESClient(url, v4)
 				if err != nil {
@@ -88,29 +88,29 @@ func main() {
 				return nil
 			},
 		},
-    // Index-specific commands
+		// Index-specific commands
 		{
 			Name:      "ingest",
 			Usage:     "Parse and ingest the input file. By default, ingests into the current production index for the provided source.",
 			ArgsUsage: "[filepath, use format 's3://bucketname/objectname' for s3]",
-      Category:  "Index actions",
-			Flags:     []cli.Flag{
+			Category:  "Index actions",
+			Flags: []cli.Flag{
 				&cli.StringFlag{
-					Name:  	  "source",
+					Name:     "source",
 					Aliases:  []string{"s"},
-					Usage: 	  "Source system of metadata file to process. Must be one of [aleph, aspace, dspace, mario]",
+					Usage:    "Source system of metadata file to process. Must be one of [aleph, aspace, dspace, mario]",
 					Required: true,
 				},
 				&cli.StringFlag{
-					Name:  	 "consumer",
+					Name:    "consumer",
 					Aliases: []string{"c"},
-					Value: 	 "es",
-					Usage: 	 "Consumer to use. Must be one of [es, json, title, silent]",
+					Value:   "es",
+					Usage:   "Consumer to use. Must be one of [es, json, title, silent]",
 				},
-        &cli.BoolFlag{
-          Name: "new",
-          Usage: "Create a new index instead of ingesting into the current production index for the source",
-        },
+				&cli.BoolFlag{
+					Name:  "new",
+					Usage: "Create a new index instead of ingesting into the current production index for the source",
+				},
 				&cli.BoolFlag{
 					Name:  "auto",
 					Usage: "Automatically promote / demote on completion",
@@ -119,11 +119,11 @@ func main() {
 			Action: func(c *cli.Context) error {
 				var es *client.ESClient
 				config := ingester.Config{
-					Filename:  c.Args().Get(0),
-					Consumer:  c.String("consumer"),
-					Source:    c.String("source"),
-          NewIndex:  c.Bool("new"),
-					Promote:   c.Bool("auto"),
+					Filename: c.Args().Get(0),
+					Consumer: c.String("consumer"),
+					Source:   c.String("source"),
+					NewIndex: c.Bool("new"),
+					Promote:  c.Bool("auto"),
 				}
 				log.Printf("Ingesting records from file: %s\n", config.Filename)
 				stream, err := ingester.NewStream(config.Filename)
@@ -148,17 +148,17 @@ func main() {
 			},
 		},
 		{
-			Name:     "promote",
-			Usage:    "Promote an index to production",
-      UsageText: "Demotes the existing production index for the provided prefix, if there is one",
-			Category: "Index actions",
-			Flags:    []cli.Flag{
-    		&cli.StringFlag{
-    			Name:     "index",
-    			Aliases:  []string{"i"},
-    			Usage:    "Name of the Elasticsearch index to promote",
-          Required: true,
-    		},
+			Name:      "promote",
+			Usage:     "Promote an index to production",
+			UsageText: "Demotes the existing production index for the provided prefix, if there is one",
+			Category:  "Index actions",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     "index",
+					Aliases:  []string{"i"},
+					Usage:    "Name of the Elasticsearch index to promote",
+					Required: true,
+				},
 			},
 			Action: func(c *cli.Context) error {
 				es, err := client.NewESClient(url, v4)
@@ -174,18 +174,18 @@ func main() {
 			Usage:     "Reindex one index to another index",
 			UsageText: "Use the Elasticsearch reindex API to copy one index to another. The doc source must be present in the original index.",
 			Category:  "Index actions",
-			Flags:     []cli.Flag{
-    		&cli.StringFlag{
-    			Name:     "index",
-    			Aliases: 	[]string{"i"},
-    			Usage:    "Name of the Elasticsearch index to copy",
-          Required: true,
-    		},
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     "index",
+					Aliases:  []string{"i"},
+					Usage:    "Name of the Elasticsearch index to copy",
+					Required: true,
+				},
 				&cli.StringFlag{
 					Name:     "destination",
-          Aliases:  []string{"d"},
+					Aliases:  []string{"d"},
 					Usage:    "Name of new index",
-          Required: true,
+					Required: true,
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -199,17 +199,17 @@ func main() {
 			},
 		},
 		{
-			Name:      "delete",
-			Usage:     "Delete an index",
-			Category:  "Index actions",
-			Flags:     []cli.Flag{
-    		&cli.StringFlag{
-    			Name:     "index",
-    			Aliases: 	[]string{"i"},
-    			Usage:    "Name of the Elasticsearch index to delete",
-          Required: true,
-    		},
-      },
+			Name:     "delete",
+			Usage:    "Delete an index",
+			Category: "Index actions",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     "index",
+					Aliases:  []string{"i"},
+					Usage:    "Name of the Elasticsearch index to delete",
+					Required: true,
+				},
+			},
 			Action: func(c *cli.Context) error {
 				es, err := client.NewESClient(url, v4)
 				if err != nil {

--- a/cmd/mario/main.go
+++ b/cmd/mario/main.go
@@ -10,13 +10,12 @@ import (
 )
 
 func main() {
-	var auto bool
-	var url, index string
+	var url string
 	var v4 bool
 
 	app := cli.NewApp()
 
-	//Global options
+	// Global options
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
 			Name:        "url",
@@ -24,12 +23,6 @@ func main() {
 			Value:       "http://127.0.0.1:9200",
 			Usage:       "URL for the Elasticsearch cluster",
 			Destination: &url,
-		},
-		&cli.StringFlag{
-			Name:        "index",
-			Aliases: 		 []string{"i"},
-			Usage:       "Name of the Elasticsearch index",
-			Destination: &index,
 		},
 		&cli.BoolFlag{
 			Name:        "v4",
@@ -39,15 +32,79 @@ func main() {
 	}
 
 	app.Commands = []*cli.Command{
+    // Elasticsearch commands
+		{
+			Name:     "aliases",
+			Usage:    "List Elasticsearch aliases and their associated indexes",
+      Category: "Elasticsearch actions",
+			Action:   func(c *cli.Context) error {
+				es, err := client.NewESClient(url, v4)
+				if err != nil {
+					return err
+				}
+				aliases, err := es.Aliases()
+				if err != nil {
+					return err
+				}
+				for _, a := range aliases {
+					fmt.Printf("Alias: %s\n\tIndex: %s\n\n", a.Alias, a.Index)
+				}
+				return nil
+			},
+		},
+    {
+			Name:     "indexes",
+			Usage:    "List all Elasticsearch indexes",
+      Category: "Elasticsearch actions",
+			Action:   func(c *cli.Context) error {
+				es, err := client.NewESClient(url, v4)
+				if err != nil {
+					return err
+				}
+				indexes, err := es.Indexes()
+				if err != nil {
+					return err
+				}
+				for _, i := range indexes {
+					fmt.Printf("Name: %s\n\tDocuments: %d\n\tHealth: %s\n\tStatus: %s\n\tUUID: %s\n\tSize: %s\n\n", i.Index, i.DocsCount, i.Health, i.Status, i.UUID, i.StoreSize)
+				}
+				return nil
+			},
+    },
+		{
+			Name:     "ping",
+			Usage:    "Ping Elasticsearch",
+      Category: "Elasticsearch actions",
+			Action: func(c *cli.Context) error {
+				es, err := client.NewESClient(url, v4)
+				if err != nil {
+					return err
+				}
+				res, err := es.Ping(url)
+				if err != nil {
+					return err
+				}
+				fmt.Printf("Name: %s\nCluster: %s\nVersion: %s\nLucene version: %s", res.Name, res.ClusterName, res.Version.Number, res.Version.LuceneVersion)
+				return nil
+			},
+		},
+    // Index-specific commands
 		{
 			Name:      "ingest",
-			Usage:     "Parse and ingest the input file",
+			Usage:     "Parse and ingest the input file to a new or existing index",
 			ArgsUsage: "[filepath, use format 's3://bucketname/objectname' for s3]",
-			Flags: []cli.Flag{
+      Category:  "Index actions",
+			Flags:     []cli.Flag{
+    		&cli.StringFlag{
+      		Name:    "index",
+    			Aliases: []string{"i"},
+    			Usage:   "Name of the Elasticsearch index to ingest to. If not included, will default to a new index named with the source prefix plus timestamp (except for Aleph update files, which are always ingested into the current production Aleph index)",
+    		},
 				&cli.StringFlag{
-					Name:  "rules",
-					Value: "/config/marc_rules.json",
-					Usage: "Path to marc rules file",
+					Name:  	  "source",
+					Aliases:  []string{"s"},
+					Usage: 	  "Source system of metadata file to process. Must be one of [aleph, aspace, dspace, mario]",
+					Required: true,
 				},
 				&cli.StringFlag{
 					Name:  	 "consumer",
@@ -55,16 +112,9 @@ func main() {
 					Value: 	 "es",
 					Usage: 	 "Consumer to use. Must be one of [es, json, title, silent]",
 				},
-				&cli.StringFlag{
-					Name:  	 "source, s",
-					Aliases: []string{"s"},
-					Usage: 	 "Source system of metadata file to process. Must be one of [aleph, aspace, dspace, mario]",
-					Required: true,
-				},
 				&cli.BoolFlag{
-					Name:        "auto",
-					Usage:       "Automatically promote / demote on completion",
-					Destination: &auto,
+					Name:  "auto",
+					Usage: "Automatically promote / demote on completion",
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -73,9 +123,8 @@ func main() {
 					Filename:  c.Args().Get(0),
 					Consumer:  c.String("consumer"),
 					Source:    c.String("source"),
-					Index:     index,
-					Promote:   auto,
-					Rulesfile: c.String("rules"),
+					Index:     c.String("index"),
+					Promote:   c.Bool("auto"),
 				}
 				log.Printf("Ingesting records from file: %s\n", config.Filename)
 				stream, err := ingester.NewStream(config.Filename)
@@ -89,7 +138,6 @@ func main() {
 						return err
 					}
 				}
-
 				ingest := ingester.Ingester{Stream: stream, Client: es}
 				err = ingest.Configure(config)
 				if err != nil {
@@ -101,115 +149,44 @@ func main() {
 			},
 		},
 		{
-			Name:  "indexes",
-			Usage: "List Elasticsearch indexes",
-			Action: func(c *cli.Context) error {
-				es, err := client.NewESClient(url, v4)
-				if err != nil {
-					return err
-				}
-				indexes, err := es.Indexes()
-				if err != nil {
-					return err
-				}
-				for _, i := range indexes {
-					fmt.Printf(`
-Name: %s
-  Documents: %d
-  Health: %s
-  Status: %s
-  UUID: %s
-  Size: %s
-`, i.Index, i.DocsCount, i.Health, i.Status, i.UUID, i.StoreSize)
-				}
-				return nil
-			},
-		},
-		{
-			Name:  "aliases",
-			Usage: "List Elasticsearch aliases and associated indexes",
-			Action: func(c *cli.Context) error {
-				es, err := client.NewESClient(url, v4)
-				if err != nil {
-					return err
-				}
-				aliases, err := es.Aliases()
-				if err != nil {
-					return err
-				}
-				for _, a := range aliases {
-					fmt.Printf(`
-Alias: %s
-  Index: %s
-`, a.Alias, a.Index)
-				}
-				return nil
-			},
-		},
-		{
-			Name:  "ping",
-			Usage: "Ping Elasticsearch",
-			Action: func(c *cli.Context) error {
-				es, err := client.NewESClient(url, v4)
-				if err != nil {
-					return err
-				}
-				res, err := es.Ping(url)
-				if err != nil {
-					return err
-				}
-				fmt.Printf(`
-Name: %s
-Cluster: %s
-Version: %s
-Lucene version: %s
-`, res.Name, res.ClusterName, res.Version.Number, res.Version.LuceneVersion)
-				return nil
-			},
-		},
-		{
-			Name:     "delete",
-			Usage:    "Delete an Elasticsearch index",
-			Category: "Index actions",
-			Action: func(c *cli.Context) error {
-				es, err := client.NewESClient(url, v4)
-				if err != nil {
-					return err
-				}
-				err = es.Delete(index)
-				return err
-			},
-		},
-		{
 			Name:     "promote",
-			Usage:    "Promote Elasticsearch alias to prod",
+			Usage:    "Promote an index to production",
+      UsageText: "Demotes the existing production index for the provided prefix, if there is one",
 			Category: "Index actions",
-			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:    "prefix",
-					Aliases: []string{"p"},
-					Usage: 	 "Index prefix to use: current options are aleph, aspace, dspace",
-					Required: true,
-				},
+			Flags:    []cli.Flag{
+    		&cli.StringFlag{
+    			Name:     "index",
+    			Aliases:  []string{"i"},
+    			Usage:    "Name of the Elasticsearch index to promote",
+          Required: true,
+    		},
 			},
 			Action: func(c *cli.Context) error {
 				es, err := client.NewESClient(url, v4)
 				if err != nil {
 					return err
 				}
-				err = es.Promote(index, c.String("prefix"))
+				err = es.Promote(c.String("index"))
 				return err
 			},
 		},
 		{
 			Name:      "reindex",
-			Usage:     "Reindex one index to another index.",
+			Usage:     "Reindex one index to another index",
 			UsageText: "Use the Elasticsearch reindex API to copy one index to another. The doc source must be present in the original index.",
 			Category:  "Index actions",
-			Flags: []cli.Flag{
+			Flags:     []cli.Flag{
+    		&cli.StringFlag{
+    			Name:     "index",
+    			Aliases: 	[]string{"i"},
+    			Usage:    "Name of the Elasticsearch index to copy",
+          Required: true,
+    		},
 				&cli.StringFlag{
-					Name:  "destination",
-					Usage: "Name of new index",
+					Name:     "destination",
+          Aliases:  []string{"d"},
+					Usage:    "Name of new index",
+          Required: true,
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -217,8 +194,29 @@ Lucene version: %s
 				if err != nil {
 					return err
 				}
-				count, err := es.Reindex(index, c.String("destination"))
+				count, err := es.Reindex(c.String("index"), c.String("destination"))
 				fmt.Printf("%d documents reindexed\n", count)
+				return err
+			},
+		},
+		{
+			Name:      "delete",
+			Usage:     "Delete an index",
+			Category:  "Index actions",
+			Flags:     []cli.Flag{
+    		&cli.StringFlag{
+    			Name:     "index",
+    			Aliases: 	[]string{"i"},
+    			Usage:    "Name of the Elasticsearch index to delete",
+          Required: true,
+    		},
+      },
+			Action: func(c *cli.Context) error {
+				es, err := client.NewESClient(url, v4)
+				if err != nil {
+					return err
+				}
+				err = es.Delete(c.String("index"))
 				return err
 			},
 		},

--- a/pkg/client/elastic.go
+++ b/pkg/client/elastic.go
@@ -29,6 +29,7 @@ type Indexer interface {
 	Promote(string) error
 	Delete(string) error
 	Reindex(string, string) (int64, error)
+  Indexes() (elastic.CatIndicesResponse, error)
 }
 
 // ESClient wraps an olivere/elastic client. Create a new client with the

--- a/pkg/client/elastic.go
+++ b/pkg/client/elastic.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"errors"
-  "strings"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
@@ -14,6 +13,7 @@ import (
 	aws "github.com/olivere/elastic/aws/v4"
 	"io/ioutil"
 	"net/http"
+	"strings"
 )
 
 // Primary alias
@@ -29,7 +29,7 @@ type Indexer interface {
 	Promote(string) error
 	Delete(string) error
 	Reindex(string, string) (int64, error)
-  Indexes() (elastic.CatIndicesResponse, error)
+	Indexes() (elastic.CatIndicesResponse, error)
 }
 
 // ESClient wraps an olivere/elastic client. Create a new client with the
@@ -112,9 +112,9 @@ func (c *ESClient) Add(record record.Record, index string, rtype string) {
 // existing index with the same prefix as the promoted index and linked to the
 // primary alias, it will be removed from the alias. This action is atomic.
 func (c ESClient) Promote(index string) error {
-  svc := c.client.Alias().Add(index, primary)
-  prefix := strings.Split(index, "-")[0]
-  current, err := c.Current(prefix)
+	svc := c.client.Alias().Add(index, primary)
+	prefix := strings.Split(index, "-")[0]
+	current, err := c.Current(prefix)
 	if err != nil {
 		return err
 	}

--- a/pkg/generator/marc.go
+++ b/pkg/generator/marc.go
@@ -44,7 +44,7 @@ type marcparser struct {
 
 //MarcGenerator parses binary MARC records.
 type MarcGenerator struct {
-	Marcfile  io.Reader
+	Marcfile io.Reader
 }
 
 //Generate a channel of Records.

--- a/pkg/generator/marc.go
+++ b/pkg/generator/marc.go
@@ -45,12 +45,11 @@ type marcparser struct {
 //MarcGenerator parses binary MARC records.
 type MarcGenerator struct {
 	Marcfile  io.Reader
-	Rulesfile string
 }
 
 //Generate a channel of Records.
 func (m *MarcGenerator) Generate() <-chan record.Record {
-	rules, err := RetrieveRules(m.Rulesfile)
+	rules, err := RetrieveRules("/config/marc_rules.json")
 	if err != nil {
 		spew.Dump(err)
 	}

--- a/pkg/generator/marc_test.go
+++ b/pkg/generator/marc_test.go
@@ -240,7 +240,7 @@ func TestMarcProcess(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	p := MarcGenerator{Marcfile: marcfile, Rulesfile: "/config/marc_rules.json"}
+	p := MarcGenerator{Marcfile: marcfile}
 	out := p.Generate()
 	var i int
 	for range out {

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -20,12 +20,12 @@ import (
 // Config is a structure for passing a set of configuration parameters to
 // an Ingester.
 type Config struct {
-	Filename  string
-	Source    string
-	Consumer  string
-  Index     string
-	NewIndex  bool
-	Promote   bool
+	Filename string
+	Source   string
+	Consumer string
+	Index    string
+	NewIndex bool
+	Promote  bool
 }
 
 // NewStream returns an io.ReadCloser from a path string. The path can be
@@ -55,13 +55,13 @@ func (i *Ingester) Configure(config Config) error {
 	var err error
 	// Configure generator
 	if config.Source == "aleph" {
-		i.generator = &generator.MarcGenerator{Marcfile:  i.Stream}
+		i.generator = &generator.MarcGenerator{Marcfile: i.Stream}
 	} else if config.Source == "aspace" {
 		i.generator = &generator.ArchivesGenerator{Archivefile: i.Stream}
 	} else if config.Source == "dspace" {
 		i.generator = &generator.DspaceGenerator{Dspacefile: i.Stream}
 	} else if config.Source == "mario" {
-			i.generator = &generator.JSONGenerator{File: i.Stream}
+		i.generator = &generator.JSONGenerator{File: i.Stream}
 	} else {
 		return errors.New("Unknown source data")
 	}
@@ -69,18 +69,18 @@ func (i *Ingester) Configure(config Config) error {
 	// Configure consumer
 	if config.Consumer == "es" {
 		if config.NewIndex == true {
-      now := time.Now().UTC()
-      config.Index = fmt.Sprintf("%s-%s", config.Source, now.Format("2006-01-02t15-04-05z"))
-    } else {
-      current, err := i.Client.Current(config.Source)
+			now := time.Now().UTC()
+			config.Index = fmt.Sprintf("%s-%s", config.Source, now.Format("2006-01-02t15-04-05z"))
+		} else {
+			current, err := i.Client.Current(config.Source)
 			if err != nil || current == "" {
-        e := fmt.Errorf("No existing production index for source '%s'. Either promote an existing %s index or add the 'new' flag to the ingest command to create a new index.", config.Source, config.Source)
+				e := fmt.Errorf("No existing production index for source '%s'. Either promote an existing %s index or add the 'new' flag to the ingest command to create a new index.", config.Source, config.Source)
 				return e
 			}
 			log.Printf("Ingesting into current production index: %s", current)
 			config.Index = current
 			config.Promote = false
-    }
+		}
 
 		err = i.Client.Create(config.Index)
 		if err != nil {
@@ -93,7 +93,6 @@ func (i *Ingester) Configure(config Config) error {
 		}
 
 		log.Printf("Configured Elasticsearch consumer using source: %s, index: %s, and promote: %s", config.Source, config.Index, strconv.FormatBool(config.Promote))
-
 
 	} else if config.Consumer == "json" {
 		i.consumer = &consumer.JSONConsumer{Out: os.Stdout}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -26,7 +26,6 @@ type Config struct {
 	Consumer  string
 	Index     string
 	Promote   bool
-	Rulesfile string
 }
 
 // NewStream returns an io.ReadCloser from a path string. The path can be
@@ -56,10 +55,7 @@ func (i *Ingester) Configure(config Config) error {
 	var err error
 	// Configure generator
 	if config.Source == "aleph" {
-		i.generator = &generator.MarcGenerator{
-			Marcfile:  i.Stream,
-			Rulesfile: config.Rulesfile,
-		}
+		i.generator = &generator.MarcGenerator{Marcfile:  i.Stream}
 	} else if config.Source == "aspace" {
 		i.generator = &generator.ArchivesGenerator{Archivefile: i.Stream}
 	} else if config.Source == "dspace" {
@@ -142,7 +138,7 @@ func (i *Ingester) Ingest() (int, error) {
 	<-out
 	if i.config.Promote {
 		log.Printf("Automatic promotion is happening")
-		err = i.Client.Promote(i.config.Index, i.config.Source)
+		err = i.Client.Promote(i.config.Index)
 	}
 	return ctr.Count, err
 }


### PR DESCRIPTION
#### What does this PR do?
The CLI has been a bit messy and confusing for some time as documented in [ADR 14](https://github.com/MITLibraries/mario/blob/6982a33e1552c0e9eea1a21ba4459cfdc37b2baf/docs/architecture-decisions/0014-structure-of-cli.md). This finishes the work to bring the CLI in line with that ADR.

* Removes index from global options
* Organizes all commands in two groups: ES actions and index actions
* Adds "required" to all required options
* Reorganizes ingest options to have index first (to match the other index commands) followed by required options, then optional ones
* Removes RulesFile option from ingest command, also removes it from the ingester configuration, and instead hard codes the rules file directly in the MARC generator (to match other MARC-specific config file handling)
* Removes prefix option from the promote command and determines the prefix from the index name within the es Promote function
* Fixes a bug in the es Promote function that would demote an index if it was already in the timdex-prod alias and it was passed to the promote command
* Updates README command examples to match the new cli

#### How can a reviewer manually see the effects of these changes?
Run `mario -h` to see the new cli help information, and run any of the updated commands (see README for examples).

#### Side effects of this change:
As noted in the ticket, the Aleph and ASpace automated ingest infrastructure needs to be redeployed with these updated commands.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DISCO-99

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
