### PR TITLE
Fix typo in MARC generator

### DIFF
--- a/pkg/generator/marc.go
+++ b/pkg/generator/marc.go
@@ -224,7 +224,7 @@ func marcToRecord(fmlRecord fml.Record, rules []*record.Rule, languageCodes map[
 		}
 		eightSixSix := getHoldings(fmlRecord, "866", []string{"b", "c", "h", "a", "z"})
 		if len(eightSixSix) > 0 {
-			r.Holdings[i].Summary += " " + eightSixSix[i].Summary
+			r.Holdings[i].Summary += " " + eightSixSix[0].Summary
 		}
 	}
 


### PR DESCRIPTION
#### What does this PR do?

Fixes a typo in the MARC generator that caused an index out-of-range panic for records with multiple 856 fields but a single 866 field.

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
