### PR TITLE
Fix bug in Dockerfile

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -2,7 +2,7 @@ name: Stage
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   test:
     name: Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Tests
 on:
   push:
     branches-ignore:
-      - master
+      - main
 jobs:
   test:
     name: Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,23 @@
-FROM golang:1.16-alpine
-
+FROM golang:1.16-alpine AS build
+ENV GO111MODULE=on
 RUN apk add --no-cache curl git ca-certificates
 RUN go get github.com/markbates/pkger/cmd/pkger
 WORKDIR /go/src/mario
 COPY go.mod .
 COPY go.sum .
 RUN go mod download
-COPY mario.go .
-COPY pkg pkg
-COPY cmd cmd
-COPY config config
+COPY . .
 RUN \
   pkger && \
-  go build -o mario cmd/mario/main.go
+  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o mario cmd/mario/main.go
 
 # Note: the two `RUN true` commands appear to be necessary because of
 # https://github.com/moby/moby/issues/37965
 FROM golang:1.16-alpine
-COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 RUN true
-COPY --from=0 /go/src/mario/mario .
+COPY --from=build /go/src/mario/mario .
 RUN true
-COPY --from=0 /go/src/mario/config ./config
+COPY --from=build /go/src/mario/config ./config
 ENTRYPOINT ["./mario"]
 CMD ["--help"]


### PR DESCRIPTION
#### What does this PR do?
* Dockerfile update to result in a successful build that will run a Mario command
* Github Actions config files now reference the main branch instead of master


#### Helpful background context
For reasons currently unknown, updates in a previous commit caused problems with the Docker build that prevented running the Mario command in the container. CI build on merge was also broken due to previous renaming of the main branch.

#### How can a reviewer manually see the effects of these changes?
`make dist` to build the docker image and then `docker run mitlibraries/mario:latest -h` to see the Mario help command

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
