### PR TITLE
Add multistage build back to 116

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM golang:1.16-alpine
-
+FROM golang:1.16-alpine AS build
 RUN apk add --no-cache curl git ca-certificates
 RUN go get github.com/markbates/pkger/cmd/pkger
 WORKDIR /go/src/mario
@@ -13,6 +12,18 @@ COPY config config
 RUN \
   pkger && \
   go build -o mario cmd/mario/main.go
+# Note: the two `RUN true` commands appear to be necessary because of
+# https://github.com/moby/moby/issues/37965
 
+FROM golang:1.16-alpine
+WORKDIR /go/src/mario
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+RUN true
+COPY --from=build /go/src/mario/mario .
+RUN true
+COPY --from=build /go/src/mario/config ./config
+run true
+COPY --from=0 /go/src/mario/go.mod ./go.mod
+RUN true
 ENTRYPOINT ["./mario"]
 CMD ["--help"]


### PR DESCRIPTION
#### What does this PR do?

This PR adds multistage builds back to the docker container. 

#### Helpful background context

The update to 1.16 broke multistage builds, as far as I can tell this is because go was expecting more verbose mod/config directives.  
These changes were based on knowledge from this post indicating mod might be the culprit.  

https://stackoverflow.com/questions/66894200/go-go-mod-file-not-found-in-current-directory-or-any-parent-directory-see-go

#### How can a reviewer manually see the effects of these changes?

Pull this branch -
 
Run `make dist`

Run `docker run mario:latest -h`

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DISCO-291

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
 NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
