### PR TITLE
Handle no 008 field error

### DIFF
--- a/pkg/generator/marc.go
+++ b/pkg/generator/marc.go
@@ -127,9 +127,13 @@ func marcToRecord(fmlRecord fml.Record, rules []*record.Rule, languageCodes map[
 		return r, err
 	}
 
-	zeroZeroEight := fmlRecord.Filter("008")[0][0]
-	if zeroZeroEight != "" && len(zeroZeroEight) != 40 {
-		err = fmt.Errorf("Record %s has illegal 008 field length of %d characters: '%s'", r.Identifier, len(zeroZeroEight), zeroZeroEight)
+	zeroZeroEight := fmlRecord.Filter("008")
+	if len(zeroZeroEight) == 0 {
+		err = fmt.Errorf("Record %s has no 008 field", r.Identifier)
+		return r, err
+	}
+	if zeroZeroEight[0][0] != "" && len(zeroZeroEight[0][0]) != 40 {
+		err = fmt.Errorf("Record %s has illegal 008 field length of %d characters: '%s'", r.Identifier, len(zeroZeroEight[0][0]), zeroZeroEight[0][0])
 		return r, err
 	}
 


### PR DESCRIPTION
#### What does this PR do?

Some records in the latest full Alma export are lacking 008 fields, which caused a panic in the MARC generator. This adds a check to skip and report any records missing an 008 field.

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
