### PR TITLE
Update Github actions to deploy from 2.x branch

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -2,7 +2,7 @@ name: Stage
 on:
   push:
     branches:
-      - main
+      - 2.x
 jobs:
   test:
     name: Tests
@@ -12,7 +12,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.13.x
+          go-version: 1.16.x
       - name: Run tests
         run: make test
   deploy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches-ignore:
       - main
+      - 2.x
 jobs:
   test:
     name: Tests
@@ -12,7 +13,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.13.x
+          go-version: 1.16.x
       - name: Run tests
         run: make test
       - name: Test docker build


### PR DESCRIPTION
#### Helpful background context
While we work on breaking changes that will result in version 3.0 of Mario, we want to retain a long-running branch for version 2.x that can be deployed to production until 3.0 is ready to go live.

#### What does this PR do?
* Updates the staging Github actions workflow to deploy the 2.x branch
* Updates the test Github actions workflow to ignore the 2.x branch in addition to main
* Updates both workflows to use our current Go version, 1.16

#### How can a reviewer manually see the effects of these changes?
I don't think we can until it's merged.

#### Side effects of this change:
All future work intended for immediate production release should be PR'd into the 2.x branch. Work to support new features can be PR'd into the main branch.

#### What are the relevant tickets?
* https://mitlibraries.atlassian.net/browse/RDI-39

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
