### PR TITLE
Disable auto-deploy from main branch

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -12,20 +12,20 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.13.x
+          go-version: 1.16.x
       - name: Run tests
         run: make test
-  deploy:
-    name: Deploy staging build
-    needs: test
-    runs-on: ubuntu-latest
-    env:
-      AWS_DEFAULT_REGION: us-east-1
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build image
-        run: make dist
-      - name: Push image
-        run: make publish
+  # deploy:
+  #   name: Deploy staging build
+  #   needs: test
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     AWS_DEFAULT_REGION: us-east-1
+  #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Build image
+  #       run: make dist
+  #     - name: Push image
+  #       run: make publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches-ignore:
       - main
+      - 2.x
 jobs:
   test:
     name: Tests
@@ -12,7 +13,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.13.x
+          go-version: 1.16.x
       - name: Run tests
         run: make test
       - name: Test docker build


### PR DESCRIPTION
#### What does this PR do?
* Comments out the deploy job in stage Github Actions workflow
* Adds 2.x branch to ignore in test Github Actions workflow
* Updates Go to our current version 1.16 in both workflows

#### Helpful background context
While we work on breaking changes that will result in version 3.0 of Mario, we don't want the main branch to auto-deploy to our current staging environment.

#### Side effects of this change:
Any desired deployments from the main branch will need to be done manually from local.

#### How can a reviewer manually see the effects of these changes?
We can't until it's merged.

#### What are the relevant tickets?
* https://mitlibraries.atlassian.net/browse/RDI-39

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval
