### PR TITLE
Actions and makefile changes for dev

### DIFF
--- a/.github/workflows/dev_ecr_push.yml
+++ b/.github/workflows/dev_ecr_push.yml
@@ -1,0 +1,37 @@
+name: dev ECR push
+on:
+  push:
+    branches:
+      - main
+# Set defaults
+defaults:
+  run:
+    shell: bash
+
+env:
+  AWS_REGION: "us-east-1"
+  AWS_ACCOUNT_ID: "222053980223"
+  IAM_ROLE: "timdex-mario-gha-dev"
+
+jobs:
+  deploy:
+    name: Deploy staging build
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ env.IAM_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Build image
+        run: make dist-dev
+      - name: Push image
+        run: make publish-dev
+

--- a/Makefile
+++ b/Makefile
@@ -18,16 +18,16 @@ tests: test
 update: ## Update dependencies
 	go get -u ./...
 
-dist: ## Build docker image
-	docker build -t $(ECR_REGISTRY)/timdex-mario:latest \
-		-t $(ECR_REGISTRY)/timdex-mario:`git describe --always` \
+dist-dev: ## Build docker image
+	docker build --platform linux/amd64 -t $(ECR_REGISTRY)/timdex-mario-dev:latest \
+		-t $(ECR_REGISTRY)/timdex-mario-dev:`git describe --always` \
 		-t timdex-mario:latest .
 
-publish: dist ## Build, tag and push
+publish-dev: dist-dev ## Build, tag and push
 	aws --profile default ecr get-login-password --region us-east-1 \
-	| docker login --username AWS --password-stdin $(ECR_REGISTRY)
-	docker push $(ECR_REGISTRY)/timdex-mario:latest
-	docker push $(ECR_REGISTRY)/timdex-mario:`git describe --always`
+	| docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_REGISTRY)
+	docker push $(ECR_REGISTRY)/timdex-mario-dev:latest
+	docker push $(ECR_REGISTRY)/timdex-mario-dev:`git describe --always`
 
 # TODO: re-write promote command for new AWS account structure, see Github issue #581
 # promote: ## Promote the current staging build to production


### PR DESCRIPTION
#### What does this PR do?
This PR modifies the makefile to work in dev, and adds the github action to compile and publish the container to dev on pushes to main.  

#### Helpful background context
While we did decide to not *tag* images with dev, stage, or prod, we still use ECR registries with dev, stage, or prod in the name.  So i add the -dev back in a few places.  
I also added the action which will compile and publish the dev image automatically on pushes to main.  
We haven't decided how to do dev->stage->prod promotion yet, so i have left that unmodified for now.  When stage is deployed, we'll decide on that and add actions/makefile commands. 

#### How can a reviewer manually see the effects of these changes?
With dev credentials, you can run `make dist-dev` and `make publish-dev` 

#### What are the relevant tickets?

Unsure, Jira is still down.

#### Requires Full Reindexing of all Sources?
NO

#### Includes new or updated dependencies?
NO


