### PR TITLE
Update Contributor model

### DIFF
--- a/fixtures/timdex_record_samples.json
+++ b/fixtures/timdex_record_samples.json
@@ -298,21 +298,21 @@
     ],
     "contributors": [
       {
-        "affiliation": "MIT",
+        "affiliation": ["MIT"],
         "kind": "author",
         "mit_affiliated": true,
         "value": "Moon, Intae"
       },
       {
-        "affiliation": "MIT",
+        "affiliation": ["MIT"],
         "kind": "author",
         "mit_affiliated": true,
         "value": "Ranjram, Mike Kavian"
       },
       {
-        "affiliation": "MIT",
+        "affiliation": ["MIT"],
         "kind": "author",
-        "identifier": "https://orcid.org/0000-0002-0746-6191",
+        "identifier": ["https://orcid.org/0000-0002-0746-6191"],
         "mit_affiliated": true,
         "value": "Perreault, David J"
       },
@@ -435,9 +435,9 @@
     ],
     "contributors": [
       {
-        "affiliation": "MIT",
+        "affiliation": ["MIT"],
         "kind": "creator",
-        "identifier": "https://lccn.loc.gov/nr99025157",
+        "identifier": ["https://lccn.loc.gov/nr99025157"],
         "mit_affiliated": true,
         "value": "Connick, Charles J. (Charles Jay)"
       }

--- a/pkg/record/record.go
+++ b/pkg/record/record.go
@@ -43,11 +43,11 @@ type AlternateTitle struct {
 
 // Contributor object
 type Contributor struct {
-	Affiliation   string `json:"affiliation,omitempty"`
-	Kind          string `json:"kind,omitempty"`
-	Identifier    string `json:"identifier,omitempty"`
-	MitAffiliated bool   `json:"mit_affiliated,omitempty"`
-	Value         string `json:"value"`
+	Affiliation   []string `json:"affiliation,omitempty"`
+	Kind          string   `json:"kind,omitempty"`
+	Identifier    []string `json:"identifier,omitempty"`
+	MitAffiliated bool     `json:"mit_affiliated,omitempty"`
+	Value         string   `json:"value"`
 }
 
 // Date object


### PR DESCRIPTION
#### What does this PR do?
In some sources, a contributor can have multiple affiliations and/or identifiers. This PR:
* Updates Contributor Affiliation and Identifier type from string to array of strings.
* Updates fixtures to reflect this change.

#### How can a reviewer manually see the effects of these changes?
Try loading the fixtures into a local OpenSearch instance or our Dev1 instance and see the updated Contributor model in the records. Also works with output from the transmogrifier app.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/RDI-79

#### Requires Full Reindexing of all Sources?
NO (has already been done on Dev1)

#### Includes new or updated dependencies?
NO